### PR TITLE
Disable publishing some packages temporarily

### DIFF
--- a/libs/modelfetch-node/package.json
+++ b/libs/modelfetch-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@modelfetch/node",
   "version": "0.0.1",
-  "license": "MIT",
+  "private": true,
   "type": "module",
   "exports": {
     ".": {

--- a/libs/modelfetch/package.json
+++ b/libs/modelfetch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "modelfetch",
   "version": "0.0.1",
-  "license": "MIT",
+  "private": true,
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary
- Mark `@modelfetch/node` and `modelfetch` packages as private to prevent accidental publishing
- This is a temporary measure while these packages are still in early development

## Test plan
- [x] Verify packages have `"private": true` instead of `"license": "MIT"`
- [x] Ensure this doesn't affect local development or workspace dependencies
- [x] Confirm packages won't be published to npm registry

🤖 Generated with [Claude Code](https://claude.ai/code)