### PR TITLE
Add create-modelfetch CLI and runtime adapters for edge platforms

### DIFF
--- a/.nx/version-plans/add-runtime-adapters-and-cli.md
+++ b/.nx/version-plans/add-runtime-adapters-and-cli.md
@@ -1,0 +1,5 @@
+---
+__default__: minor
+---
+
+Add create-modelfetch CLI and runtime adapters for Cloudflare, Vercel, and Netlify

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,9 @@ The SDK is built as a thin wrapper on top of `hono` and `@hono/mcp`, leveraging 
 - `@modelfetch/node` - Node.js runtime support (work in progress)
 - `@modelfetch/bun` - Bun runtime support (work in progress)
 - `@modelfetch/deno` - Deno runtime support (work in progress)
-- `@modelfetch/cloudflare` - Cloudflare Workers support (planned)
-- `@modelfetch/vercel` - Vercel Functions support (planned)
+- `@modelfetch/cloudflare` - Cloudflare Workers support (work in progress)
+- `@modelfetch/vercel` - Vercel Functions support (work in progress)
+- `@modelfetch/netlify` - Netlify Functions support (work in progress)
 
 Each package acts as a thin wrapper around the equivalent Hono package, ensuring optimal performance and compatibility.
 
@@ -39,6 +40,7 @@ This workspace follows Nx best practices as outlined in @.cursor/rules/nx-rules.
 - All JavaScript projects have no ESLint configurations
 - All Nx projects use automatic configuration provided by Nx plugins instead of individual `project.json` files
 - All local dependencies use `workspace:^` version specifier
+- Dependencies and devDependencies that are already available in the root package.json should NOT be included in individual project package.json files. This includes common dependencies like `typescript`, `@types/node`, `eslint`, `prettier`, `nx`, `@nx/*`, `@swc/*`, etc.
 
 ### Core Applications
 
@@ -62,8 +64,9 @@ These projects are example applications powered by ModelFetch:
 - `@modelfetch/node`: Node.js runtime support (work in progress)
 - `@modelfetch/bun`: Bun runtime support (work in progress)
 - `@modelfetch/deno`: Deno runtime support (work in progress)
-- `@modelfetch/cloudflare`: Cloudflare Workers support (planned)
-- `@modelfetch/vercel`: Vercel Functions support (planned)
+- `@modelfetch/cloudflare`: Cloudflare Workers support (work in progress)
+- `@modelfetch/vercel`: Vercel Functions support (work in progress)
+- `@modelfetch/netlify`: Netlify Functions support (work in progress)
 
 ### Supporting Libraries
 
@@ -118,6 +121,12 @@ File/folder names and their primary exports must always match using the followin
   - `theme-switch` folder/file → `ThemeSwitch` component
   - `button.tsx` → `Button` component
   - `do-something.ts` → `doSomething` function
+
+Constants and variables use camelCase, not CONSTANT_CASE:
+
+- Use `packageVersions` instead of `PACKAGE_VERSIONS`
+- Use `apiUrl` instead of `API_URL`
+- This applies to all constants, even those that are never reassigned
 
 ### Type Definitions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ lib/
 
 ### Naming Conventions
 
-File/folder names and their primary exports must always match using the following convention:
+All file/folder names and their primary exports must always match using the following convention:
 
 - Kebab-case for files/folders → PascalCase or camelCase for exports
 - Examples:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,10 +28,9 @@ The `modelfetch` CLI provides an exceptional developer experience with:
 
 This workspace follows Nx best practices as outlined in @.cursor/rules/nx-rules.mdc
 
-### Global Configurations
+### Workspace Configurations
 
 - Node.js version: @.nvmrc
-- Workspace configurations: @package.json @pnpm-workspace.yaml
 - TypeScript configurations: @tsconfig.base.json @tsconfig.bun.json @tsconfig.deno.json @tsconfig.next.json
 - TypeScript project references are used to improve the performance of TypeScript-related features
   - All TypeScript projects are referenced in the root @tsconfig.json
@@ -40,7 +39,7 @@ This workspace follows Nx best practices as outlined in @.cursor/rules/nx-rules.
 - All JavaScript projects have no ESLint configurations
 - All Nx projects use automatic configuration provided by Nx plugins instead of individual `project.json` files
 - All local dependencies use `workspace:^` version specifier
-- Dependencies and devDependencies that are already available in the root package.json should NOT be included in individual project package.json files. This includes common dependencies like `typescript`, `@types/node`, `eslint`, `prettier`, `nx`, `@nx/*`, `@swc/*`, etc.
+- `dependencies` and `devDependencies` that are already available in the root @package.json should NOT be included in individual project package.json files. This includes common dependencies like `typescript`, `@types/node`, `eslint`, `prettier`, `nx`, `@nx/*`, `@swc/*`, etc.
 
 ### Core Applications
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,11 +121,11 @@ File/folder names and their primary exports must always match using the followin
   - `button.tsx` → `Button` component
   - `do-something.ts` → `doSomething` function
 
-Constants and variables use camelCase, not CONSTANT_CASE:
+All constants and variables use camelCase, not CONSTANT_CASE:
 
-- Use `packageVersions` instead of `PACKAGE_VERSIONS`
-- Use `apiUrl` instead of `API_URL`
-- This applies to all constants, even those that are never reassigned
+- Examples:
+  - Use `packageVersions` instead of `PACKAGE_VERSIONS`
+  - Use `apiUrl` instead of `API_URL`
 
 ### Type Definitions
 

--- a/apps/example-bun-js/package.json
+++ b/apps/example-bun-js/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.13.3",
     "@modelfetch/bun": "workspace:^",
-    "zod": "^3.25.67"
+    "zod": "^3.25.72"
   },
   "devDependencies": {
     "modelfetch": "workspace:^"

--- a/apps/example-bun-ts/package.json
+++ b/apps/example-bun-ts/package.json
@@ -7,10 +7,10 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.13.3",
     "@modelfetch/bun": "workspace:^",
-    "zod": "^3.25.67"
+    "zod": "^3.25.72"
   },
   "devDependencies": {
-    "@types/bun": "^1.2.17",
+    "@types/bun": "^1.2.18",
     "create-eslint-config": "workspace:^",
     "modelfetch": "workspace:^"
   }

--- a/apps/example-deno-js/package.json
+++ b/apps/example-deno-js/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.13.3",
     "@modelfetch/deno": "workspace:^",
-    "zod": "^3.25.67"
+    "zod": "^3.25.72"
   },
   "devDependencies": {
     "modelfetch": "workspace:^"

--- a/apps/example-deno-ts/package.json
+++ b/apps/example-deno-ts/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.13.3",
     "@modelfetch/deno": "workspace:^",
-    "zod": "^3.25.67"
+    "zod": "^3.25.72"
   },
   "devDependencies": {
     "@types/deno": "^2.3.0",

--- a/apps/example-node-js/package.json
+++ b/apps/example-node-js/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.13.3",
     "@modelfetch/node": "workspace:^",
-    "zod": "^3.25.67"
+    "zod": "^3.25.72"
   },
   "devDependencies": {
     "modelfetch": "workspace:^"

--- a/apps/example-node-ts/package.json
+++ b/apps/example-node-ts/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.13.3",
     "@modelfetch/node": "workspace:^",
-    "zod": "^3.25.67"
+    "zod": "^3.25.72"
   },
   "devDependencies": {
     "create-eslint-config": "workspace:^",

--- a/apps/modelfetch-website/app/page.tsx
+++ b/apps/modelfetch-website/app/page.tsx
@@ -195,7 +195,16 @@ npm install @modelfetch/node
 bun add @modelfetch/bun
 
 # For Deno
-deno add jsr:@modelfetch/deno`}
+deno add jsr:@modelfetch/deno
+
+# For Cloudflare
+npm install @modelfetch/cloudflare
+
+# For Vercel
+npm install @modelfetch/vercel
+
+# For Netlify
+npm install @modelfetch/netlify`}
                         lang="bash"
                       />
                     </div>

--- a/apps/modelfetch-website/app/page.tsx
+++ b/apps/modelfetch-website/app/page.tsx
@@ -138,8 +138,8 @@ export default function Page() {
                     <span className="mr-2">◈</span>Multi-Runtime
                   </h3>
                   <p className="text-gray-400">
-                    Write your MCP servers once. Run them anywhere
-                    TypeScript/JavaScript runs: Node.js, Bun, Deno, etc.
+                    Write your MCP server once. Run it anywhere: Node.js, Bun,
+                    Deno, Cloudflare, Vercel, Netlify, etc.
                   </p>
                 </div>
                 <div className="group rounded border border-gray-300 bg-white p-4 shadow-md transition-all hover:border-[#008f00] hover:shadow-[0_0_20px_rgba(0,143,0,0.3)] sm:p-6 dark:border-[#333] dark:bg-[#1a1a1a] dark:shadow-none dark:hover:border-[#00ff00] dark:hover:shadow-[0_0_20px_rgba(0,255,0,0.3)]">
@@ -147,7 +147,7 @@ export default function Page() {
                     <span className="mr-2">◈</span>Delightful DX
                   </h3>
                   <p className="text-gray-400">
-                    Build your MCP servers with tools designed for building MCP
+                    Build your MCP server with tools designed for building MCP
                     servers: live reload, MCP Inspector, etc.
                   </p>
                 </div>
@@ -175,7 +175,7 @@ export default function Page() {
                     <span className="text-[#008f00] dark:text-[#00ff00]">
                       $
                     </span>{" "}
-                    Install a ModelFetch runtime of your choice:
+                    Install ModelFetch runtime for your environment:
                   </p>
                   <div className="overflow-hidden rounded-lg border border-gray-300 bg-white shadow-md transition-colors hover:border-[#008f00] dark:border-[#333] dark:bg-[#1a1a1a] dark:shadow-none dark:hover:border-[#00ff00]">
                     <div className="flex items-center justify-between border-b border-gray-300 bg-gray-100 px-4 py-2 dark:border-[#333] dark:bg-[#2a2a2a]">
@@ -195,7 +195,7 @@ npm install @modelfetch/node
 bun add @modelfetch/bun
 
 # For Deno
-deno add jsr:@modelfetch/deno
+deno add npm:@modelfetch/deno
 
 # For Cloudflare
 npm install @modelfetch/cloudflare
@@ -234,7 +234,7 @@ import { z } from "zod";
 
 const server = new McpServer({
   title: "My MCP Server",
-  name: "my-server",
+  name: "my-mcp-server",
   version: "1.0.0",
 });
 

--- a/apps/modelfetch-website/mdx/examples/deno.mdx
+++ b/apps/modelfetch-website/mdx/examples/deno.mdx
@@ -60,7 +60,7 @@ export default server;
 ### index.ts
 
 ```typescript
-import handle, { getEndpoint } from "jsr:@modelfetch/deno";
+import handle, { getEndpoint } from "npm:@modelfetch/deno";
 
 import server from "./server.ts";
 
@@ -79,7 +79,7 @@ if (address) {
     "strict": true
   },
   "imports": {
-    "@modelfetch/deno": "jsr:@modelfetch/deno",
+    "@modelfetch/deno": "npm:@modelfetch/deno",
     "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@^0.7.0",
     "zod": "npm:zod@^3.24.1"
   },
@@ -148,7 +148,7 @@ export default server;
 ### index.js
 
 ```javascript
-import handle, { getEndpoint } from "jsr:@modelfetch/deno";
+import handle, { getEndpoint } from "npm:@modelfetch/deno";
 
 import server from "./server.js";
 
@@ -167,7 +167,7 @@ if (address) {
     "strict": true
   },
   "imports": {
-    "@modelfetch/deno": "jsr:@modelfetch/deno",
+    "@modelfetch/deno": "npm:@modelfetch/deno",
     "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@^0.7.0",
     "zod": "npm:zod@^3.24.1"
   },
@@ -194,7 +194,6 @@ deno run -A src/index.js
 Deno uses explicit import specifiers:
 
 - `npm:` - For npm packages
-- `jsr:` - For JSR (JavaScript Registry) packages
 - File imports include extensions (`.ts`, `.js`)
 
 ### Permissions Model

--- a/apps/modelfetch-website/mdx/getting-started.mdx
+++ b/apps/modelfetch-website/mdx/getting-started.mdx
@@ -39,6 +39,36 @@ bun add @modelfetch/bun
 deno add jsr:@modelfetch/deno
 ```
 
+### Cloudflare
+
+```bash
+npm install @modelfetch/cloudflare
+# or
+yarn add @modelfetch/cloudflare
+# or
+pnpm add @modelfetch/cloudflare
+```
+
+### Vercel
+
+```bash
+npm install @modelfetch/vercel
+# or
+yarn add @modelfetch/vercel
+# or
+pnpm add @modelfetch/vercel
+```
+
+### Netlify
+
+```bash
+npm install @modelfetch/netlify
+# or
+yarn add @modelfetch/netlify
+# or
+pnpm add @modelfetch/netlify
+```
+
 ## Creating Your First MCP Server
 
 Let's create a simple MCP server that provides a greeting tool.
@@ -81,7 +111,7 @@ export default server;
 Create an `index.ts` file to handle the server with ModelFetch:
 
 ```typescript title="index.ts"
-import handle, { getEndpoint } from "@modelfetch/node"; // or @modelfetch/bun, @modelfetch/deno
+import handle, { getEndpoint } from "@modelfetch/node"; // or @modelfetch/bun, @modelfetch/deno, @modelfetch/vercel, @modelfetch/netlify
 import server from "./server";
 
 // Start the server (Node.js example)
@@ -89,9 +119,11 @@ handle(server, (address) => {
   console.log(`MCP Server is available at ${getEndpoint(address)}`);
 });
 
-// Note: Bun and Deno have different patterns:
+// Note: Other runtimes have different patterns:
 // Bun: const bunServer = handle(server); console.log(getEndpoint(bunServer));
 // Deno: const httpServer = handle(server); if (httpServer.addr) console.log(getEndpoint(httpServer.addr));
+// Vercel: export const GET = handle(server); export const POST = handle(server);
+// Netlify: export const handler = handle(server);
 ```
 
 ### 3. Run the server
@@ -118,6 +150,43 @@ bun run index.ts
 
 ```bash
 deno run -A index.ts
+```
+
+#### Vercel
+
+For Vercel, you'll typically deploy as an API route:
+
+```typescript title="app/api/mcp/route.ts"
+import handle from "@modelfetch/vercel";
+import server from "./server";
+
+export const runtime = "edge"; // or "nodejs"
+
+export const GET = handle(server);
+export const POST = handle(server);
+```
+
+Then deploy with:
+
+```bash
+vercel
+```
+
+#### Netlify
+
+For Netlify, create a serverless function:
+
+```typescript title="netlify/functions/mcp.ts"
+import handle from "@modelfetch/netlify";
+import server from "./server";
+
+export const handler = handle(server);
+```
+
+Then deploy with:
+
+```bash
+netlify deploy
 ```
 
 ## Understanding the Basics

--- a/apps/modelfetch-website/mdx/getting-started.mdx
+++ b/apps/modelfetch-website/mdx/getting-started.mdx
@@ -154,13 +154,11 @@ deno run -A index.ts
 
 #### Vercel
 
-For Vercel, you'll typically deploy as an API route:
+For Vercel, create an API route in your Next.js app:
 
-```typescript title="app/api/mcp/route.ts"
+```typescript title="app/mcp/route.ts"
 import handle from "@modelfetch/vercel";
 import server from "./server";
-
-export const runtime = "edge"; // or "nodejs"
 
 const handler = handle(server);
 export const GET = handler;

--- a/apps/modelfetch-website/mdx/getting-started.mdx
+++ b/apps/modelfetch-website/mdx/getting-started.mdx
@@ -36,7 +36,7 @@ bun add @modelfetch/bun
 ### Deno
 
 ```bash
-deno add jsr:@modelfetch/deno
+deno add npm:@modelfetch/deno
 ```
 
 ### Cloudflare

--- a/apps/modelfetch-website/mdx/getting-started.mdx
+++ b/apps/modelfetch-website/mdx/getting-started.mdx
@@ -122,7 +122,7 @@ handle(server, (address) => {
 // Note: Other runtimes have different patterns:
 // Bun: const bunServer = handle(server); console.log(getEndpoint(bunServer));
 // Deno: const httpServer = handle(server); if (httpServer.addr) console.log(getEndpoint(httpServer.addr));
-// Vercel: export const GET = handle(server); export const POST = handle(server);
+// Vercel: const handler = handle(server); export const GET = handler; export const POST = handler; export const DELETE = handler;
 // Netlify: export const handler = handle(server);
 ```
 
@@ -162,8 +162,10 @@ import server from "./server";
 
 export const runtime = "edge"; // or "nodejs"
 
-export const GET = handle(server);
-export const POST = handle(server);
+const handler = handle(server);
+export const GET = handler;
+export const POST = handler;
+export const DELETE = handler;
 ```
 
 Then deploy with:

--- a/apps/modelfetch-website/mdx/index.mdx
+++ b/apps/modelfetch-website/mdx/index.mdx
@@ -24,8 +24,13 @@ ModelFetch is currently a work in progress. The following packages are available
 - `@modelfetch/node` - Node.js runtime support
 - `@modelfetch/bun` - Bun runtime support
 - `@modelfetch/deno` - Deno runtime support
+- `@modelfetch/cloudflare` - Cloudflare Workers support
+- `@modelfetch/vercel` - Vercel Functions support (Edge Runtime and Node.js)
+- `@modelfetch/netlify` - Netlify Functions support
 
-The CLI tools and additional runtime support (Cloudflare Workers, Vercel Functions) are under development.
+Additional packages are under active development:
+
+- `modelfetch` CLI - Developer tools with live reload and MCP inspector integration
 
 ## Quick Example
 
@@ -59,7 +64,7 @@ export default server;
 ```
 
 ```typescript title="index.ts"
-import handle from "@modelfetch/node"; // or @modelfetch/bun, @modelfetch/deno
+import handle from "@modelfetch/node"; // or @modelfetch/bun, @modelfetch/deno, @modelfetch/cloudflare, @modelfetch/vercel, @modelfetch/netlify
 import server from "./server";
 
 handle(server);

--- a/apps/modelfetch-website/mdx/runtimes/cloudflare.mdx
+++ b/apps/modelfetch-website/mdx/runtimes/cloudflare.mdx
@@ -1,0 +1,518 @@
+---
+title: Cloudflare
+description: Deploy MCP servers to Cloudflare Workers
+---
+
+The `@modelfetch/cloudflare` package provides ModelFetch support for deploying MCP servers to Cloudflare Workers, leveraging the power of the edge network for global, low-latency deployments.
+
+## Installation
+
+```bash
+npm install @modelfetch/cloudflare
+# or
+yarn add @modelfetch/cloudflare
+# or
+pnpm add @modelfetch/cloudflare
+```
+
+## Basic Usage
+
+### Cloudflare Workers
+
+```typescript title="src/index.ts"
+import handle from "@modelfetch/cloudflare";
+import server from "./server";
+
+export default handle(server);
+```
+
+### With Custom Handlers
+
+```typescript title="src/index.ts"
+import handle from "@modelfetch/cloudflare";
+import server from "./server";
+
+interface Env {
+  MY_KV: KVNamespace;
+  MY_API_KEY: string;
+}
+
+// Add custom handlers like scheduled, queue, etc.
+export default handle<Env>(server, {
+  scheduled: async (event, env, ctx) => {
+    console.log("Running scheduled task");
+    // Your scheduled task logic
+  },
+  queue: async (batch, env, ctx) => {
+    console.log(`Processing ${batch.messages.length} messages`);
+    // Your queue processing logic
+  },
+});
+```
+
+### Manual Integration
+
+If you need more control over the fetch handler:
+
+```typescript title="src/index.ts"
+import handle from "@modelfetch/cloudflare";
+import type { Options } from "@modelfetch/cloudflare";
+import server from "./server";
+
+interface Env {
+  MY_KV: KVNamespace;
+  MY_API_KEY: string;
+}
+
+// Define handlers separately for better organization
+const options: Options<Env> = {
+  scheduled: async (event, env, ctx) => {
+    // Your scheduled task logic
+  },
+  trace: async (traces, env, ctx) => {
+    // Handle trace events
+  },
+};
+
+// Option 1: Use the handle function
+export default handle<Env>(server, options);
+
+// Option 2: Manual integration
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    const handler = handle<Env>(server);
+    return handler.fetch(request, env, ctx);
+  },
+  ...options,
+};
+```
+
+## API Reference
+
+### Type Exports
+
+#### `Options<Env, QueueHandlerMessage, CfHostMetadata>`
+
+Type for additional Cloudflare Workers handlers, excluding the `fetch` handler which is provided by ModelFetch.
+
+```typescript
+import type { Options } from "@modelfetch/cloudflare";
+
+type Options<Env, QueueHandlerMessage, CfHostMetadata> = {
+  tail?: ExportedHandlerTailHandler<Env>;
+  trace?: ExportedHandlerTraceHandler<Env>;
+  scheduled?: ExportedHandlerScheduledHandler<Env>;
+  queue?: ExportedHandlerQueueHandler<Env, QueueHandlerMessage>;
+  test?: ExportedHandlerTestHandler<Env>;
+  email?: EmailExportedHandler<Env>;
+};
+```
+
+### `handle(server, options?)`
+
+Creates a Cloudflare Workers-compatible handler from a ModelFetch server.
+
+- **server**: The MCP server instance from `@modelcontextprotocol/sdk`
+- **options** (optional): Additional Cloudflare Workers handlers (scheduled, queue, email, etc.)
+
+Returns an `ExportedHandler` object compatible with Cloudflare Workers.
+
+#### Type Parameters
+
+```typescript
+handle<Env, QueueHandlerMessage, CfHostMetadata>(
+  server: Server,
+  options?: Options<Env, QueueHandlerMessage, CfHostMetadata>
+): ExportedHandler<Env, QueueHandlerMessage, CfHostMetadata>
+```
+
+- **Env**: Environment bindings type (KV, R2, D1, etc.)
+- **QueueHandlerMessage**: Message type for queue handlers
+- **CfHostMetadata**: Cloudflare-specific host metadata type
+
+#### Examples
+
+```typescript
+import handle from "@modelfetch/cloudflare";
+import server from "./server";
+
+// Basic usage
+const handler = handle(server);
+
+// With typed environment
+interface Env {
+  MY_KV: KVNamespace;
+  MY_QUEUE: Queue<MessageType>;
+}
+
+const typedHandler = handle<Env>(server);
+
+// With additional handlers
+const handlerWithScheduled = handle<Env>(server, {
+  scheduled: async (event, env, ctx) => {
+    // env is typed as Env
+    await env.MY_KV.put("last-run", Date.now().toString());
+  },
+});
+```
+
+### Type Exports
+
+```typescript
+import type { Options } from "@modelfetch/cloudflare";
+
+// Use when defining handlers separately
+const myHandlers: Options<Env> = {
+  scheduled: async (event, env, ctx) => {
+    // ...
+  },
+  queue: async (batch, env, ctx) => {
+    // ...
+  },
+};
+
+export default handle(server, myHandlers);
+```
+
+## Deployment
+
+### Using Wrangler CLI
+
+```bash
+# Install Wrangler
+npm install -g wrangler
+
+# Initialize a new project
+wrangler init my-mcp-server
+
+# Deploy
+wrangler deploy
+```
+
+### wrangler.toml Configuration
+
+```toml title="wrangler.toml"
+name = "my-mcp-server"
+main = "src/index.ts"
+compatibility_date = "2024-01-01"
+
+[env.production]
+vars = { ENVIRONMENT = "production" }
+
+[[kv_namespaces]]
+binding = "MY_KV"
+id = "your-kv-namespace-id"
+
+[[r2_buckets]]
+binding = "MY_BUCKET"
+bucket_name = "my-bucket"
+
+[[d1_databases]]
+binding = "MY_DB"
+database_name = "my-database"
+database_id = "your-database-id"
+```
+
+### Environment Variables and Bindings
+
+Access Cloudflare bindings in your MCP server:
+
+```typescript title="server.ts"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const server = new McpServer({
+  title: "My MCP Server",
+  name: "my-server",
+  version: "1.0.0",
+});
+
+// Access bindings through the handler
+export default {
+  async fetch(request: Request, env: MyEnv, ctx: ExecutionContext) {
+    // Use env.MY_KV, env.MY_API_KEY, etc.
+    const handler = handle(server);
+    return handler(request, env, ctx);
+  },
+};
+```
+
+## Example Server
+
+Here's a complete example of an MCP server for Cloudflare Workers:
+
+```typescript title="server.ts"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+const server = new McpServer({
+  title: "KV Store MCP Server",
+  name: "kv-store-server",
+  version: "1.0.0",
+});
+
+// KV storage tool
+server.tool(
+  "kv_get",
+  "Get a value from KV store",
+  { key: z.string() },
+  async ({ key }, { env }) => {
+    const value = await env.MY_KV.get(key);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: value || "Key not found",
+        },
+      ],
+    };
+  },
+);
+
+server.tool(
+  "kv_put",
+  "Store a value in KV store",
+  { key: z.string(), value: z.string() },
+  async ({ key, value }, { env }) => {
+    await env.MY_KV.put(key, value);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Stored ${key} = ${value}`,
+        },
+      ],
+    };
+  },
+);
+
+export default server;
+```
+
+```typescript title="src/index.ts"
+import handle from "@modelfetch/cloudflare";
+import server from "./server";
+
+interface Env {
+  MY_KV: KVNamespace;
+}
+
+export default handle<Env>(server);
+```
+
+### Example with Queues
+
+Here's an example combining MCP server with Cloudflare Queues:
+
+```typescript title="src/index.ts"
+import handle from "@modelfetch/cloudflare";
+import server from "./server";
+
+interface Env {
+  MY_QUEUE: Queue;
+  ERROR_LOG: R2Bucket;
+}
+
+interface QueueMessage {
+  id: string;
+  data: Record<string, unknown>;
+}
+
+export default handle<Env, QueueMessage>(server, {
+  async queue(batch, env, ctx) {
+    // Process typed messages from the queue
+    for (const message of batch.messages) {
+      try {
+        // message.body is typed as QueueMessage
+        console.log("Processing:", message.body.id, message.body.data);
+
+        // Mark as acknowledged
+        message.ack();
+      } catch (error) {
+        // Log errors to R2
+        await env.ERROR_LOG.put(
+          `errors/${Date.now()}.json`,
+          JSON.stringify({
+            error: error.message,
+            messageId: message.body.id,
+            data: message.body.data,
+          }),
+        );
+
+        // Retry the message
+        message.retry();
+      }
+    }
+  },
+
+  async scheduled(event, env, ctx) {
+    // Run cleanup tasks every hour
+    console.log("Running scheduled cleanup at", event.cron);
+
+    // Clean up old error logs
+    const listing = await env.ERROR_LOG.list();
+    const oneWeekAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+
+    for (const object of listing.objects) {
+      const timestamp = parseInt(object.key.split("/")[1].split(".")[0]);
+      if (timestamp < oneWeekAgo) {
+        await env.ERROR_LOG.delete(object.key);
+      }
+    }
+  },
+});
+```
+
+## Features
+
+### Edge Network Benefits
+
+- **Global deployment**: Deploy to 300+ cities worldwide
+- **Low latency**: Serve requests from the nearest edge location
+- **Automatic scaling**: Handle millions of requests without configuration
+- **Zero cold starts**: Workers are always warm at the edge
+
+### Cloudflare Services Integration
+
+- **KV Storage**: Key-value storage at the edge
+- **R2 Storage**: S3-compatible object storage
+- **D1 Database**: SQLite at the edge
+- **Durable Objects**: Stateful serverless computing
+- **Queues**: Message queuing service
+- **Workers AI**: Run AI models at the edge
+
+## Best Practices
+
+### Performance Optimization
+
+1. Use KV for frequently accessed data
+2. Implement caching strategies
+3. Minimize external API calls
+4. Use Workers AI for ML tasks when possible
+
+### Security
+
+1. Store secrets as environment variables
+2. Validate all input parameters
+3. Use Cloudflare Access for authentication
+4. Enable rate limiting with Cloudflare
+
+### Error Handling
+
+```typescript
+server.tool(
+  "safe_operation",
+  "Demonstrates error handling",
+  { input: z.string() },
+  async ({ input }) => {
+    try {
+      // Your operation
+      const result = await riskyOperation(input);
+      return {
+        content: [{ type: "text", text: result }],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error: ${error.message}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+);
+```
+
+## Limitations
+
+### Workers Limitations
+
+- 128MB memory limit
+- 10ms CPU time limit (50ms for paid plans)
+- 1MB request/response size (100MB for Enterprise)
+- No file system access
+- Limited to Web Standard APIs
+
+### Workarounds
+
+- Use R2 for file storage
+- Use D1 for relational data
+- Use Durable Objects for state
+- Use Workers AI for compute-intensive tasks
+
+## Troubleshooting
+
+### Common Issues
+
+**Module not found errors**
+
+```json
+// Ensure compatibility_flags in wrangler.toml
+{
+  "compatibility_flags": ["nodejs_compat"]
+}
+```
+
+**Environment variables not accessible**
+
+```typescript
+// Access through env parameter, not process.env
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    console.log(env.MY_VAR); // ✓ Correct
+    console.log(process.env.MY_VAR); // ✗ Won't work
+  },
+};
+```
+
+**Timeout errors**
+
+```typescript
+// Use ctx.waitUntil for background tasks
+ctx.waitUntil(doBackgroundWork().catch((err) => console.error(err)));
+```
+
+## Local Development
+
+### Using Wrangler Dev
+
+```bash
+# Start local development server
+wrangler dev
+
+# With local persistence
+wrangler dev --local --persist
+```
+
+### Testing with Miniflare
+
+```typescript title="test/server.test.ts"
+import { Miniflare } from "miniflare";
+import handle from "@modelfetch/cloudflare";
+import server from "../src/server";
+
+const mf = new Miniflare({
+  script: `
+    export default {
+      fetch: ${handle(server).toString()}
+    }
+  `,
+  kvNamespaces: ["MY_KV"],
+});
+
+test("server responds", async () => {
+  const response = await mf.dispatchFetch("http://localhost/mcp");
+  expect(response.status).toBe(200);
+});
+```
+
+## Next Steps
+
+- Read the [MCP SDK documentation](https://docs.mcp.io)
+- Explore [Cloudflare Workers documentation](https://developers.cloudflare.com/workers/)
+- Learn about [Workers best practices](https://developers.cloudflare.com/workers/best-practices/)
+- Check out [example implementations](/docs/examples)

--- a/apps/modelfetch-website/mdx/runtimes/cloudflare.mdx
+++ b/apps/modelfetch-website/mdx/runtimes/cloudflare.mdx
@@ -23,10 +23,12 @@ pnpm add @modelfetch/cloudflare
 import handle from "@modelfetch/cloudflare";
 import server from "./server";
 
-export default handle(server);
+export default {
+  fetch: handle(server),
+};
 ```
 
-### With Custom Handlers
+### With Additional Handlers
 
 ```typescript title="src/index.ts"
 import handle from "@modelfetch/cloudflare";
@@ -37,8 +39,8 @@ interface Env {
   MY_API_KEY: string;
 }
 
-// Add custom handlers like scheduled, queue, etc.
-export default handle<Env>(server, {
+export default {
+  fetch: handle(server),
   scheduled: async (event, env, ctx) => {
     console.log("Running scheduled task");
     // Your scheduled task logic
@@ -47,16 +49,13 @@ export default handle<Env>(server, {
     console.log(`Processing ${batch.messages.length} messages`);
     // Your queue processing logic
   },
-});
+};
 ```
 
-### Manual Integration
-
-If you need more control over the fetch handler:
+### With Environment Types
 
 ```typescript title="src/index.ts"
 import handle from "@modelfetch/cloudflare";
-import type { Options } from "@modelfetch/cloudflare";
 import server from "./server";
 
 interface Env {
@@ -64,71 +63,26 @@ interface Env {
   MY_API_KEY: string;
 }
 
-// Define handlers separately for better organization
-const options: Options<Env> = {
-  scheduled: async (event, env, ctx) => {
-    // Your scheduled task logic
+export default {
+  fetch: handle(server),
+  scheduled: async (event, env: Env, ctx) => {
+    // Your scheduled task logic with typed environment
   },
-  trace: async (traces, env, ctx) => {
+  trace: async (traces, env: Env, ctx) => {
     // Handle trace events
   },
-};
-
-// Option 1: Use the handle function
-export default handle<Env>(server, options);
-
-// Option 2: Manual integration
-export default {
-  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
-    const handler = handle<Env>(server);
-    return handler.fetch(request, env, ctx);
-  },
-  ...options,
 };
 ```
 
 ## API Reference
 
-### Type Exports
+### `handle(server)`
 
-#### `Options<Env, QueueHandlerMessage, CfHostMetadata>`
-
-Type for additional Cloudflare Workers handlers, excluding the `fetch` handler which is provided by ModelFetch.
-
-```typescript
-import type { Options } from "@modelfetch/cloudflare";
-
-type Options<Env, QueueHandlerMessage, CfHostMetadata> = {
-  tail?: ExportedHandlerTailHandler<Env>;
-  trace?: ExportedHandlerTraceHandler<Env>;
-  scheduled?: ExportedHandlerScheduledHandler<Env>;
-  queue?: ExportedHandlerQueueHandler<Env, QueueHandlerMessage>;
-  test?: ExportedHandlerTestHandler<Env>;
-  email?: EmailExportedHandler<Env>;
-};
-```
-
-### `handle(server, options?)`
-
-Creates a Cloudflare Workers-compatible handler from a ModelFetch server.
+Creates a Cloudflare Workers fetch handler from a ModelFetch server.
 
 - **server**: The MCP server instance from `@modelcontextprotocol/sdk`
-- **options** (optional): Additional Cloudflare Workers handlers (scheduled, queue, email, etc.)
 
-Returns an `ExportedHandler` object compatible with Cloudflare Workers.
-
-#### Type Parameters
-
-```typescript
-handle<Env, QueueHandlerMessage, CfHostMetadata>(
-  server: Server,
-  options?: Options<Env, QueueHandlerMessage, CfHostMetadata>
-): ExportedHandler<Env, QueueHandlerMessage, CfHostMetadata>
-```
-
-- **Env**: Environment bindings type (KV, R2, D1, etc.)
-- **QueueHandlerMessage**: Message type for queue handlers
-- **CfHostMetadata**: Cloudflare-specific host metadata type
+Returns a fetch function compatible with Cloudflare Workers.
 
 #### Examples
 
@@ -137,41 +91,23 @@ import handle from "@modelfetch/cloudflare";
 import server from "./server";
 
 // Basic usage
-const handler = handle(server);
+export default {
+  fetch: handle(server),
+};
 
-// With typed environment
+// With typed environment and additional handlers
 interface Env {
   MY_KV: KVNamespace;
   MY_QUEUE: Queue<MessageType>;
 }
 
-const typedHandler = handle<Env>(server);
-
-// With additional handlers
-const handlerWithScheduled = handle<Env>(server, {
-  scheduled: async (event, env, ctx) => {
+export default {
+  fetch: handle(server),
+  scheduled: async (event, env: Env, ctx) => {
     // env is typed as Env
     await env.MY_KV.put("last-run", Date.now().toString());
   },
-});
-```
-
-### Type Exports
-
-```typescript
-import type { Options } from "@modelfetch/cloudflare";
-
-// Use when defining handlers separately
-const myHandlers: Options<Env> = {
-  scheduled: async (event, env, ctx) => {
-    // ...
-  },
-  queue: async (batch, env, ctx) => {
-    // ...
-  },
 };
-
-export default handle(server, myHandlers);
 ```
 
 ## Deployment
@@ -215,23 +151,22 @@ database_id = "your-database-id"
 
 ### Environment Variables and Bindings
 
-Access Cloudflare bindings in your MCP server:
+Cloudflare bindings are accessible through the environment parameter in your Workers handlers:
 
-```typescript title="server.ts"
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+```typescript title="src/index.ts"
+import handle from "@modelfetch/cloudflare";
+import server from "./server";
 
-const server = new McpServer({
-  title: "My MCP Server",
-  name: "my-server",
-  version: "1.0.0",
-});
+interface MyEnv {
+  MY_KV: KVNamespace;
+  MY_API_KEY: string;
+}
 
-// Access bindings through the handler
 export default {
-  async fetch(request: Request, env: MyEnv, ctx: ExecutionContext) {
-    // Use env.MY_KV, env.MY_API_KEY, etc.
-    const handler = handle(server);
-    return handler(request, env, ctx);
+  fetch: handle(server),
+  async scheduled(event, env: MyEnv, ctx) {
+    // Access env.MY_KV, env.MY_API_KEY, etc.
+    await env.MY_KV.put("scheduled-run", new Date().toISOString());
   },
 };
 ```
@@ -298,7 +233,9 @@ interface Env {
   MY_KV: KVNamespace;
 }
 
-export default handle<Env>(server);
+export default {
+  fetch: handle(server),
+};
 ```
 
 ### Example with Queues
@@ -319,8 +256,14 @@ interface QueueMessage {
   data: Record<string, unknown>;
 }
 
-export default handle<Env, QueueMessage>(server, {
-  async queue(batch, env, ctx) {
+export default {
+  fetch: handle(server),
+
+  async queue(
+    batch: MessageBatch<QueueMessage>,
+    env: Env,
+    ctx: ExecutionContext,
+  ) {
     // Process typed messages from the queue
     for (const message of batch.messages) {
       try {
@@ -346,7 +289,7 @@ export default handle<Env, QueueMessage>(server, {
     }
   },
 
-  async scheduled(event, env, ctx) {
+  async scheduled(event, env: Env, ctx) {
     // Run cleanup tasks every hour
     console.log("Running scheduled cleanup at", event.cron);
 
@@ -361,7 +304,7 @@ export default handle<Env, QueueMessage>(server, {
       }
     }
   },
-});
+};
 ```
 
 ## Features
@@ -462,7 +405,8 @@ server.tool(
 ```typescript
 // Access through env parameter, not process.env
 export default {
-  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+  fetch: handle(server),
+  async scheduled(event, env: Env, ctx) {
     console.log(env.MY_VAR); // ✓ Correct
     console.log(process.env.MY_VAR); // ✗ Won't work
   },
@@ -496,9 +440,13 @@ import handle from "@modelfetch/cloudflare";
 import server from "../src/server";
 
 const mf = new Miniflare({
+  modules: true,
   script: `
+    import handle from "@modelfetch/cloudflare";
+    import server from "../src/server";
+    
     export default {
-      fetch: ${handle(server).toString()}
+      fetch: handle(server)
     }
   `,
   kvNamespaces: ["MY_KV"],

--- a/apps/modelfetch-website/mdx/runtimes/deno.mdx
+++ b/apps/modelfetch-website/mdx/runtimes/deno.mdx
@@ -8,7 +8,7 @@ The `@modelfetch/deno` package provides ModelFetch support for Deno applications
 ## Installation
 
 ```bash
-deno add jsr:@modelfetch/deno
+deno add npm:@modelfetch/deno
 ```
 
 ## Basic Usage
@@ -42,7 +42,7 @@ export default server;
 ```
 
 ```typescript title="index.ts"
-import handle, { getEndpoint } from "jsr:@modelfetch/deno";
+import handle, { getEndpoint } from "npm:@modelfetch/deno";
 import server from "./server.ts";
 
 // Start the server
@@ -68,7 +68,7 @@ Starts the MCP server with Deno-specific optimizations and returns a Deno.HttpSe
 - **options**: Optional Deno.ServeOptions for configuring the HTTP server
 
 ```typescript
-import handle from "jsr:@modelfetch/deno";
+import handle from "npm:@modelfetch/deno";
 import server from "./server.ts";
 
 const httpServer = handle(server, {
@@ -89,7 +89,7 @@ Gets the MCP server endpoint for connecting clients.
 - **address**: Required. A Deno.Addr object from the HTTP server
 
 ```typescript
-import handle, { getEndpoint } from "jsr:@modelfetch/deno";
+import handle, { getEndpoint } from "npm:@modelfetch/deno";
 import server from "./server.ts";
 
 const httpServer = handle(server);
@@ -109,7 +109,7 @@ ModelFetch leverages Deno's unique capabilities:
 1. **Security by default**: Explicit permissions model
 2. **Native TypeScript**: First-class TypeScript support
 3. **Web APIs**: Uses standard Web APIs like fetch
-4. **JSR packages**: Native support for JSR registry
+4. **NPM packages**: Native support for NPM packages
 
 ### Permission Management
 
@@ -224,7 +224,7 @@ Optional `deno.json` configuration:
     "strict": true
   },
   "imports": {
-    "@modelfetch/deno": "jsr:@modelfetch/deno",
+    "@modelfetch/deno": "npm:@modelfetch/deno",
     "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@^0.7.0",
     "zod": "npm:zod@^3.24.1"
   },

--- a/apps/modelfetch-website/mdx/runtimes/index.mdx
+++ b/apps/modelfetch-website/mdx/runtimes/index.mdx
@@ -23,6 +23,21 @@ ModelFetch provides runtime-specific packages that handle the platform details w
     description="Secure MCP servers with Deno v2"
     href="/docs/runtimes/deno"
   />
+  <Card
+    title="Cloudflare"
+    description="Deploy MCP servers to Cloudflare Workers"
+    href="/docs/runtimes/cloudflare"
+  />
+  <Card
+    title="Vercel"
+    description="Deploy MCP servers to Vercel Functions"
+    href="/docs/runtimes/vercel"
+  />
+  <Card
+    title="Netlify"
+    description="Deploy MCP servers to Netlify Functions"
+    href="/docs/runtimes/netlify"
+  />
 </Cards>
 
 ## Common API
@@ -67,6 +82,33 @@ Choose Deno when:
 - You prefer web standard APIs
 - You need built-in development tools (formatter, linter, test runner)
 
+### Cloudflare
+
+Choose Cloudflare when:
+
+- You want global edge deployment with ultra-low latency
+- You need zero cold starts and instant scaling
+- You're building stateful applications with Durable Objects
+- You want to leverage Cloudflare's ecosystem (KV, R2, D1, Workers AI)
+
+### Vercel
+
+Choose Vercel when:
+
+- You're deploying to Vercel's infrastructure
+- You want serverless MCP endpoints
+- You need both Edge Runtime and Node.js Runtime options
+- You're building Next.js applications with MCP integration
+
+### Netlify
+
+Choose Netlify when:
+
+- You're deploying to Netlify's infrastructure
+- You want serverless Functions with generous free tier
+- You need background functions for long-running tasks
+- You're building JAMstack applications
+
 ## Installation
 
 Each runtime has its own package:
@@ -89,16 +131,36 @@ bun add @modelfetch/bun
 deno add jsr:@modelfetch/deno
 ```
 
+### Cloudflare
+
+```bash
+npm install @modelfetch/cloudflare
+```
+
+### Vercel
+
+```bash
+npm install @modelfetch/vercel
+```
+
+### Netlify
+
+```bash
+npm install @modelfetch/netlify
+```
+
 ## Runtime Features Comparison
 
-| Feature            | Node.js         | Bun       | Deno      |
-| ------------------ | --------------- | --------- | --------- |
-| TypeScript Support | Via tsx/ts-node | Native    | Native    |
-| Package Manager    | npm/yarn/pnpm   | Built-in  | Built-in  |
-| Permissions Model  | No              | No        | Yes       |
-| Startup Speed      | Good            | Excellent | Good      |
-| Ecosystem          | Largest         | Growing   | Growing   |
-| Web Standards      | Partial         | Good      | Excellent |
+| Feature            | Node.js         | Bun         | Deno        | Cloudflare    | Vercel        | Netlify       |
+| ------------------ | --------------- | ----------- | ----------- | ------------- | ------------- | ------------- |
+| TypeScript Support | Via tsx/ts-node | Native      | Native      | Native        | Native        | Native        |
+| Package Manager    | npm/yarn/pnpm   | Built-in    | Built-in    | npm/yarn/pnpm | npm/yarn/pnpm | npm/yarn/pnpm |
+| Permissions Model  | No              | No          | Yes         | No            | No            | No            |
+| Startup Speed      | Good            | Excellent   | Good        | Instant       | Excellent     | Good          |
+| Ecosystem          | Largest         | Growing     | Growing     | Web Standards | Largest       | Largest       |
+| Web Standards      | Partial         | Good        | Excellent   | Excellent     | Excellent     | Good          |
+| Deployment         | Self-hosted     | Self-hosted | Self-hosted | Edge Network  | Serverless    | Serverless    |
+| Background Jobs    | Yes             | Yes         | Yes         | Via Queues    | Limited       | Yes           |
 
 ## Server Compatibility
 
@@ -137,6 +199,9 @@ Only the runtime handler import changes:
 - `@modelfetch/node` for Node.js
 - `@modelfetch/bun` for Bun
 - `@modelfetch/deno` for Deno
+- `@modelfetch/cloudflare` for Cloudflare Workers
+- `@modelfetch/vercel` for Vercel Functions
+- `@modelfetch/netlify` for Netlify Functions
 
 ## Development Workflow
 
@@ -151,11 +216,7 @@ All runtimes support a similar development workflow:
 
 ## Future Runtimes
 
-ModelFetch is actively working on support for:
-
-- **Cloudflare Workers** - Deploy MCP servers on the edge
-- **Vercel Functions** - Serverless MCP servers
-- **AWS Lambda** - Enterprise serverless deployment
+ModelFetch continues to expand runtime support. Additional runtimes will follow the same simple API pattern, making it easy to deploy your MCP servers anywhere.
 
 ## Next Steps
 

--- a/apps/modelfetch-website/mdx/runtimes/index.mdx
+++ b/apps/modelfetch-website/mdx/runtimes/index.mdx
@@ -128,7 +128,7 @@ bun add @modelfetch/bun
 ### Deno
 
 ```bash
-deno add jsr:@modelfetch/deno
+deno add npm:@modelfetch/deno
 ```
 
 ### Cloudflare

--- a/apps/modelfetch-website/mdx/runtimes/meta.json
+++ b/apps/modelfetch-website/mdx/runtimes/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Runtime Packages",
-  "pages": ["node", "bun", "deno"]
+  "pages": ["node", "bun", "deno", "cloudflare", "vercel", "netlify"]
 }

--- a/apps/modelfetch-website/mdx/runtimes/netlify.mdx
+++ b/apps/modelfetch-website/mdx/runtimes/netlify.mdx
@@ -1,0 +1,397 @@
+---
+title: Netlify
+description: Deploy MCP servers to Netlify Functions
+---
+
+The `@modelfetch/netlify` package provides ModelFetch support for deploying MCP servers to Netlify Functions.
+
+## Installation
+
+```bash
+npm install @modelfetch/netlify
+# or
+yarn add @modelfetch/netlify
+# or
+pnpm add @modelfetch/netlify
+```
+
+## Basic Usage
+
+### Netlify Functions
+
+Create a function in your `netlify/functions` directory:
+
+```typescript title="netlify/functions/mcp.ts"
+import handle from "@modelfetch/netlify";
+import server from "../../server";
+
+export const handler = handle(server);
+```
+
+### Configuration
+
+Configure your function in `netlify.toml`:
+
+```toml title="netlify.toml"
+[functions]
+  directory = "netlify/functions"
+  node_bundler = "esbuild"
+
+[[redirects]]
+  from = "/api/mcp"
+  to = "/.netlify/functions/mcp"
+  status = 200
+```
+
+## API Reference
+
+### `handle(server)`
+
+Creates a Netlify-compatible handler from a ModelFetch server.
+
+- **server**: The MCP server instance from `@modelcontextprotocol/sdk`
+
+Returns a handler function compatible with Netlify Functions.
+
+```typescript
+import handle from "@modelfetch/netlify";
+import server from "./server";
+
+export const handler = handle(server);
+```
+
+## Features
+
+### Background Functions
+
+For long-running MCP operations, use Netlify Background Functions by configuring them in `netlify.toml`:
+
+```toml
+[functions."mcp-background"]
+  schedule = "@daily"
+```
+
+```typescript title="netlify/functions/mcp-background.ts"
+import handle from "@modelfetch/netlify";
+import server from "../../server";
+
+export const handler = handle(server);
+```
+
+### Environment Variables
+
+Set environment variables in the Netlify dashboard or using the CLI:
+
+```bash
+netlify env:set MY_API_KEY "your-api-key"
+```
+
+Access them in your MCP server:
+
+```typescript
+const server = new McpServer({
+  title: "My MCP Server",
+  name: "my-server",
+  version: "1.0.0",
+});
+
+server.tool("get_api_key", "Returns the API key", {}, () => ({
+  content: [
+    {
+      type: "text",
+      text: process.env.MY_API_KEY || "Not set",
+    },
+  ],
+}));
+```
+
+### CORS Configuration
+
+Configure CORS headers in your `netlify.toml`:
+
+```toml
+[[headers]]
+  for = "/.netlify/functions/mcp"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"
+    Access-Control-Allow-Headers = "Content-Type"
+    Access-Control-Allow-Methods = "GET, POST, OPTIONS"
+```
+
+## Deployment
+
+### Using Netlify CLI
+
+```bash
+# Install Netlify CLI
+npm i -g netlify-cli
+
+# Login to Netlify
+netlify login
+
+# Deploy
+netlify deploy --prod
+```
+
+### Using Git Integration
+
+1. Push your code to GitHub, GitLab, or Bitbucket
+2. Import your project in the Netlify dashboard
+3. Configure build settings:
+   - Build command: `npm run build` (if needed)
+   - Functions directory: `netlify/functions`
+4. Deploy automatically on every push
+
+### Build Configuration
+
+For TypeScript projects, configure the build in `netlify.toml`:
+
+```toml
+[build]
+  command = "npm run build"
+  functions = "netlify/functions"
+
+[functions]
+  node_bundler = "esbuild"
+
+  [functions."mcp"]
+    external_node_modules = ["@modelcontextprotocol/sdk"]
+```
+
+## Example Server
+
+Here's a complete example of an MCP server for Netlify:
+
+```typescript title="server.ts"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+const server = new McpServer({
+  title: "Todo MCP Server",
+  name: "todo-server",
+  version: "1.0.0",
+});
+
+// In-memory todo storage
+const todos: Map<string, { text: string; done: boolean }> = new Map();
+
+// Add todo tool
+server.tool(
+  "add_todo",
+  "Add a new todo item",
+  { text: z.string() },
+  ({ text }) => {
+    const id = Date.now().toString();
+    todos.set(id, { text, done: false });
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Added todo: ${text} (ID: ${id})`,
+        },
+      ],
+    };
+  },
+);
+
+// List todos tool
+server.tool("list_todos", "List all todo items", {}, () => {
+  const todoList = Array.from(todos.entries())
+    .map(([id, todo]) => `${id}: [${todo.done ? "✓" : " "}] ${todo.text}`)
+    .join("\n");
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: todoList || "No todos yet!",
+      },
+    ],
+  };
+});
+
+export default server;
+```
+
+```typescript title="netlify/functions/mcp.ts"
+import handle from "@modelfetch/netlify";
+import server from "../../server";
+
+export const handler = handle(server);
+```
+
+## Best Practices
+
+### Function Organization
+
+- Keep MCP servers in a separate file for reusability
+- Use TypeScript for better type safety
+- Organize related tools into modules
+
+### Performance Optimization
+
+1. **Bundle Size**: Keep dependencies minimal
+2. **Cold Starts**: Use lightweight initialization
+3. **Caching**: Implement caching for expensive operations
+4. **Connection Pooling**: Reuse database connections
+
+### Security
+
+1. **API Keys**: Store sensitive data in environment variables
+2. **Input Validation**: Always validate tool parameters
+3. **Rate Limiting**: Implement rate limiting for public endpoints
+4. **Authentication**: Add authentication if needed
+
+### Error Handling
+
+```typescript
+server.tool(
+  "safe_operation",
+  "Performs a safe operation",
+  { input: z.string() },
+  async ({ input }) => {
+    try {
+      // Your operation here
+      const result = await riskyOperation(input);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Success: ${result}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error: ${error.message}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+);
+```
+
+## Limitations
+
+### Function Limitations
+
+- 10 second timeout for synchronous functions
+- 15 minute timeout for background functions
+- 6MB response size limit
+- 50MB memory limit (can be increased)
+
+### Development Limitations
+
+- No WebSocket support
+- Limited file system access
+- No persistent storage (use external databases)
+
+## Local Development
+
+### Netlify Dev
+
+Test your functions locally:
+
+```bash
+# Install dependencies
+npm install
+
+# Start local development server
+netlify dev
+```
+
+Your MCP server will be available at `http://localhost:8888/.netlify/functions/mcp`.
+
+### Testing
+
+```typescript title="tests/mcp.test.ts"
+import { handler } from "../netlify/functions/mcp";
+import type { HandlerEvent, HandlerContext } from "@netlify/functions";
+
+describe("MCP Server", () => {
+  it("handles requests", async () => {
+    const event: HandlerEvent = {
+      httpMethod: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "tools/list",
+        id: 1,
+      }),
+    };
+
+    const response = await handler(event, {} as HandlerContext);
+    expect(response.statusCode).toBe(200);
+  });
+});
+```
+
+## Troubleshooting
+
+### Common Issues
+
+**Function not found**
+
+```toml
+# Ensure functions directory is configured
+[functions]
+  directory = "netlify/functions"
+```
+
+**TypeScript errors**
+
+```json
+// tsconfig.json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "esModuleInterop": true
+  }
+}
+```
+
+**Module not found**
+
+```toml
+# Configure external modules if needed
+[functions."mcp"]
+  external_node_modules = ["some-native-module"]
+```
+
+**CORS errors**
+
+Configure CORS headers in `netlify.toml` as shown in the CORS Configuration section above.
+
+## Monitoring
+
+### Function Logs
+
+View function logs in the Netlify dashboard or CLI:
+
+```bash
+netlify functions:log mcp --tail
+```
+
+### Analytics
+
+Track function usage in the Netlify Analytics dashboard:
+
+- Invocation count
+- Error rate
+- Duration metrics
+- Geographic distribution
+
+## Next Steps
+
+- Read the [MCP SDK documentation](https://docs.mcp.io)
+- Explore [Netlify Functions docs](https://docs.netlify.com/functions/overview/)
+- Check out [example implementations](/docs/examples)
+- Learn about [background functions](https://docs.netlify.com/functions/background-functions/)

--- a/apps/modelfetch-website/mdx/runtimes/vercel.mdx
+++ b/apps/modelfetch-website/mdx/runtimes/vercel.mdx
@@ -17,8 +17,6 @@ pnpm add @modelfetch/vercel
 
 ## Basic Usage
 
-### Next.js App Router
-
 ```typescript title="app/api/mcp/route.ts"
 import handle from "@modelfetch/vercel";
 import server from "./server";
@@ -26,38 +24,11 @@ import server from "./server";
 // Choose your runtime
 export const runtime = "edge"; // or "nodejs"
 
-// Export handlers for both GET and POST
-export const GET = handle(server);
-export const POST = handle(server);
-```
-
-### Next.js Pages Router
-
-```typescript title="pages/api/mcp.ts"
-import type { PageConfig } from "next";
-import handle from "@modelfetch/vercel";
-import server from "./server";
-
-// Configure the runtime
-export const config: PageConfig = {
-  runtime: "edge", // or "nodejs"
-};
-
-// Export the handler as default
-export default handle(server);
-```
-
-### Standalone Vercel Functions
-
-```typescript title="api/mcp.ts"
-import handle from "@modelfetch/vercel";
-import server from "./server";
-
-export const config = {
-  runtime: "edge", // or "nodejs"
-};
-
-export default handle(server);
+// Create handler once and export for all methods
+const handler = handle(server);
+export const GET = handler;
+export const POST = handler;
+export const DELETE = handler;
 ```
 
 ## API Reference
@@ -198,8 +169,10 @@ import server from "./server";
 
 export const runtime = "edge";
 
-export const GET = handle(server);
-export const POST = handle(server);
+const handler = handle(server);
+export const GET = handler;
+export const POST = handler;
+export const DELETE = handler;
 ```
 
 ## Best Practices

--- a/apps/modelfetch-website/mdx/runtimes/vercel.mdx
+++ b/apps/modelfetch-website/mdx/runtimes/vercel.mdx
@@ -17,14 +17,12 @@ pnpm add @modelfetch/vercel
 
 ## Basic Usage
 
-```typescript title="app/api/mcp/route.ts"
+Create an API route in your Next.js app:
+
+```typescript title="app/mcp/route.ts"
 import handle from "@modelfetch/vercel";
 import server from "./server";
 
-// Choose your runtime
-export const runtime = "edge"; // or "nodejs"
-
-// Create handler once and export for all methods
 const handler = handle(server);
 export const GET = handler;
 export const POST = handler;
@@ -163,11 +161,9 @@ server.tool(
 export default server;
 ```
 
-```typescript title="app/api/mcp/route.ts"
+```typescript title="app/mcp/route.ts"
 import handle from "@modelfetch/vercel";
 import server from "./server";
-
-export const runtime = "edge";
 
 const handler = handle(server);
 export const GET = handler;

--- a/apps/modelfetch-website/mdx/runtimes/vercel.mdx
+++ b/apps/modelfetch-website/mdx/runtimes/vercel.mdx
@@ -1,0 +1,296 @@
+---
+title: Vercel
+description: Deploy MCP servers to Vercel Functions
+---
+
+The `@modelfetch/vercel` package provides ModelFetch support for deploying MCP servers to Vercel Functions, supporting both Edge Runtime and Node.js Runtime.
+
+## Installation
+
+```bash
+npm install @modelfetch/vercel
+# or
+yarn add @modelfetch/vercel
+# or
+pnpm add @modelfetch/vercel
+```
+
+## Basic Usage
+
+### Next.js App Router
+
+```typescript title="app/api/mcp/route.ts"
+import handle from "@modelfetch/vercel";
+import server from "./server";
+
+// Choose your runtime
+export const runtime = "edge"; // or "nodejs"
+
+// Export handlers for both GET and POST
+export const GET = handle(server);
+export const POST = handle(server);
+```
+
+### Next.js Pages Router
+
+```typescript title="pages/api/mcp.ts"
+import type { PageConfig } from "next";
+import handle from "@modelfetch/vercel";
+import server from "./server";
+
+// Configure the runtime
+export const config: PageConfig = {
+  runtime: "edge", // or "nodejs"
+};
+
+// Export the handler as default
+export default handle(server);
+```
+
+### Standalone Vercel Functions
+
+```typescript title="api/mcp.ts"
+import handle from "@modelfetch/vercel";
+import server from "./server";
+
+export const config = {
+  runtime: "edge", // or "nodejs"
+};
+
+export default handle(server);
+```
+
+## API Reference
+
+### `handle(server)`
+
+Creates a Vercel-compatible handler from a ModelFetch server.
+
+- **server**: The MCP server instance from `@modelcontextprotocol/sdk`
+
+Returns a handler function compatible with Vercel's runtime.
+
+```typescript
+import handle from "@modelfetch/vercel";
+import server from "./server";
+
+const handler = handle(server);
+// Use as GET, POST exports or default export
+```
+
+## Runtime Options
+
+### Edge Runtime
+
+The Edge Runtime provides:
+
+- Faster cold starts
+- Global edge deployment
+- Web standard APIs
+- Lower memory usage
+
+```typescript
+export const runtime = "edge";
+```
+
+### Node.js Runtime
+
+The Node.js Runtime provides:
+
+- Full Node.js API compatibility
+- Larger memory limits
+- Broader package ecosystem support
+- File system access
+
+```typescript
+export const runtime = "nodejs";
+```
+
+## Deployment
+
+### Using Vercel CLI
+
+```bash
+# Install Vercel CLI
+npm i -g vercel
+
+# Deploy
+vercel
+```
+
+### Using Git Integration
+
+1. Push your code to GitHub, GitLab, or Bitbucket
+2. Import your project in the Vercel dashboard
+3. Vercel will automatically deploy on every push
+
+### Environment Variables
+
+Set environment variables in the Vercel dashboard or using the CLI:
+
+```bash
+vercel env add MY_API_KEY
+```
+
+Access them in your MCP server:
+
+```typescript
+const server = new McpServer({
+  title: "My MCP Server",
+  name: "my-server",
+  version: "1.0.0",
+});
+
+server.tool("get_api_key", "Returns the API key", {}, () => ({
+  content: [
+    {
+      type: "text",
+      text: process.env.MY_API_KEY || "Not set",
+    },
+  ],
+}));
+```
+
+## Example Server
+
+Here's a complete example of an MCP server for Vercel:
+
+```typescript title="server.ts"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+const server = new McpServer({
+  title: "Weather MCP Server",
+  name: "weather-server",
+  version: "1.0.0",
+});
+
+// Simple weather tool
+server.tool(
+  "get_weather",
+  "Get the weather for a location",
+  { location: z.string() },
+  async ({ location }) => {
+    // In a real app, you'd call a weather API
+    const weather = {
+      location,
+      temperature: Math.floor(Math.random() * 30) + 10,
+      condition: ["sunny", "cloudy", "rainy"][Math.floor(Math.random() * 3)],
+    };
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Weather in ${weather.location}: ${weather.temperature}°C, ${weather.condition}`,
+        },
+      ],
+    };
+  },
+);
+
+export default server;
+```
+
+```typescript title="app/api/mcp/route.ts"
+import handle from "@modelfetch/vercel";
+import server from "./server";
+
+export const runtime = "edge";
+
+export const GET = handle(server);
+export const POST = handle(server);
+```
+
+## Best Practices
+
+### Choose the Right Runtime
+
+- Use **Edge Runtime** for:
+  - Simple MCP servers
+  - Fast response times
+  - Global distribution
+  - Lower costs
+
+- Use **Node.js Runtime** for:
+  - Complex MCP servers
+  - File system operations
+  - Heavy computations
+  - Specific Node.js packages
+
+### Optimize Cold Starts
+
+1. Keep dependencies minimal
+2. Use Edge Runtime when possible
+3. Implement proper caching
+4. Use Vercel's ISR for static responses
+
+### Security
+
+1. Always validate input parameters
+2. Use environment variables for secrets
+3. Implement rate limiting for public endpoints
+4. Enable CORS only for trusted origins
+
+## Limitations
+
+### Edge Runtime Limitations
+
+- No Node.js-specific APIs
+- Limited to Web Standard APIs
+- 1MB response size limit
+- 25 second timeout
+
+### Node.js Runtime Limitations
+
+- 10 second default timeout (configurable)
+- 4.5MB response size limit
+- Cold start latency
+
+## Troubleshooting
+
+### Common Issues
+
+**Function timeout**
+
+```typescript
+// Increase timeout for Node.js runtime
+export const config = {
+  runtime: "nodejs",
+  maxDuration: 60, // seconds
+};
+```
+
+**Module not found**
+
+```json
+// Ensure dependencies are in package.json
+{
+  "dependencies": {
+    "@modelfetch/vercel": "^0.0.1",
+    "@modelcontextprotocol/sdk": "^0.0.1"
+  }
+}
+```
+
+**CORS errors**
+
+```typescript
+// Add CORS headers if needed
+export async function OPTIONS(request: Request) {
+  return new Response(null, {
+    status: 200,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    },
+  });
+}
+```
+
+## Next Steps
+
+- Read the [MCP SDK documentation](https://docs.mcp.io)
+- Explore [example implementations](/docs/examples)
+- Learn about [MCP concepts](/docs/concepts)

--- a/apps/modelfetch-website/package.json
+++ b/apps/modelfetch-website/package.json
@@ -9,14 +9,14 @@
     "fumadocs-mdx": "^11.6.10",
     "fumadocs-ui": "^15.6.1",
     "lucide-react": "^0.525.0",
-    "next": "^15.3.4",
+    "next": "^15.3.5",
     "next-themes": "^0.4.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "zod": "^3.25.67"
+    "zod": "^3.25.72"
   },
   "devDependencies": {
-    "@next/eslint-plugin-next": "^15.3.4",
+    "@next/eslint-plugin-next": "^15.3.5",
     "@tailwindcss/postcss": "^4.1.11",
     "@types/mdx": "^2.0.13",
     "@types/react": "^19.1.8",

--- a/libs/create-eslint-config/src/index.js
+++ b/libs/create-eslint-config/src/index.js
@@ -59,7 +59,14 @@ export default function createESLintConfig(...configs) {
         ],
         "@typescript-eslint/no-restricted-types": [
           "error",
-          { types: { Omit: true } },
+          {
+            types: {
+              Omit: {
+                message: "Use `Except` from `type-fest` instead",
+                suggest: ["Except"],
+              },
+            },
+          },
         ],
         "@typescript-eslint/no-unused-vars": [
           "error",

--- a/libs/create-modelfetch/bin/index.js
+++ b/libs/create-modelfetch/bin/index.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+await import("../dist/index.js");

--- a/libs/create-modelfetch/eslint.config.js
+++ b/libs/create-modelfetch/eslint.config.js
@@ -1,0 +1,5 @@
+import createESLintConfig from "create-eslint-config";
+
+const eslintConfig = createESLintConfig();
+
+export default eslintConfig;

--- a/libs/create-modelfetch/package.json
+++ b/libs/create-modelfetch/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "create-modelfetch",
+  "version": "0.0.1",
+  "description": "CLI for scaffolding a new MCP server with ModelFetch",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/phuctm97/modelfetch.git",
+    "directory": "libs/create-modelfetch"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "bin": {
+    "create-modelfetch": "./bin/index.js"
+  },
+  "files": [
+    "dist",
+    "bin",
+    "templates"
+  ],
+  "dependencies": {
+    "@clack/prompts": "^0.8.2",
+    "ejs": "^3.1.10",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "create-eslint-config": "workspace:^"
+  }
+}

--- a/libs/create-modelfetch/package.json
+++ b/libs/create-modelfetch/package.json
@@ -26,9 +26,11 @@
   "dependencies": {
     "@clack/prompts": "^0.11.0",
     "ejs": "^3.1.10",
-    "picocolors": "^1.1.1"
+    "picocolors": "^1.1.1",
+    "validate-npm-package-name": "^6.0.0"
   },
   "devDependencies": {
+    "@types/validate-npm-package-name": "^4.0.2",
     "create-eslint-config": "workspace:^"
   }
 }

--- a/libs/create-modelfetch/package.json
+++ b/libs/create-modelfetch/package.json
@@ -24,7 +24,7 @@
     "templates"
   ],
   "dependencies": {
-    "@clack/prompts": "^0.8.2",
+    "@clack/prompts": "^0.11.0",
     "ejs": "^3.1.10",
     "picocolors": "^1.1.1"
   },

--- a/libs/create-modelfetch/src/index.ts
+++ b/libs/create-modelfetch/src/index.ts
@@ -146,21 +146,9 @@ async function main() {
   const runtime = (await p.select({
     message: "Which runtime would you like to use?",
     options: [
-      {
-        value: "node",
-        label: "Node.js",
-        hint: "Universal JavaScript runtime",
-      },
-      {
-        value: "bun",
-        label: "Bun",
-        hint: "Fast all-in-one JavaScript runtime",
-      },
-      {
-        value: "deno",
-        label: "Deno",
-        hint: "Secure runtime for JavaScript and TypeScript",
-      },
+      { value: "node", label: "Node.js" },
+      { value: "bun", label: "Bun" },
+      { value: "deno", label: "Deno" },
     ],
   })) as Runtime;
 
@@ -172,15 +160,8 @@ async function main() {
   const language = (await p.select({
     message: "Which language would you like to use?",
     options: [
-      {
-        value: "typescript",
-        label: "TypeScript",
-        hint: "Recommended for better type safety",
-      },
-      {
-        value: "javascript",
-        label: "JavaScript",
-      },
+      { value: "typescript", label: "TypeScript" },
+      { value: "javascript", label: "JavaScript" },
     ],
   })) as Language;
 

--- a/libs/create-modelfetch/src/index.ts
+++ b/libs/create-modelfetch/src/index.ts
@@ -1,0 +1,345 @@
+import * as p from "@clack/prompts";
+import ejs from "ejs";
+import { exec } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+import pc from "picocolors";
+
+const execAsync = promisify(exec);
+
+// Package versions
+const packageVersions = {
+  "@modelcontextprotocol/sdk": "^1.13.3",
+  "@modelfetch/node": "^0.0.1",
+  tslib: "^2.8.1",
+  zod: "^3.25.67",
+  tsx: "^4.20.3",
+};
+
+type Runtime = "node" | "bun" | "deno";
+type Language = "javascript" | "typescript";
+type ServerType = "tools" | "resources" | "prompts" | "hybrid";
+type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
+
+interface ProjectOptions {
+  name: string;
+  title: string;
+  runtime: Runtime;
+  language: Language;
+  serverType: ServerType;
+  packageManager: PackageManager;
+  installDeps: boolean;
+}
+
+async function detectPackageManager(): Promise<PackageManager> {
+  const userAgent = process.env.npm_config_user_agent;
+
+  if (userAgent) {
+    if (userAgent.includes("pnpm")) return "pnpm";
+    if (userAgent.includes("yarn")) return "yarn";
+    if (userAgent.includes("bun")) return "bun";
+  }
+
+  // Check for lock files
+  try {
+    await fs.access("pnpm-lock.yaml");
+    return "pnpm";
+  } catch {
+    // Ignore error
+  }
+
+  try {
+    await fs.access("yarn.lock");
+    return "yarn";
+  } catch {
+    // Ignore error
+  }
+
+  try {
+    await fs.access("bun.lockb");
+    return "bun";
+  } catch {
+    // Ignore error
+  }
+
+  return "npm";
+}
+
+function validateProjectName(name: string): string | undefined {
+  if (!name) return "Project name is required";
+  if (!/^[a-z0-9-_.]+$/.test(name))
+    return "Project name can only contain lowercase letters, numbers, hyphens, underscores, and dots";
+
+  if (/^[._]/.test(name))
+    return "Project name cannot start with a dot or underscore";
+
+  return undefined;
+}
+
+async function copyTemplate(
+  templatePath: string,
+  targetPath: string,
+  options: ProjectOptions,
+) {
+  await fs.mkdir(targetPath, { recursive: true });
+
+  const files = await fs.readdir(templatePath);
+
+  // Prepare EJS data
+  const ejsData = {
+    projectName: options.name,
+    projectTitle: options.title,
+    runtime: options.runtime,
+    language: options.language,
+    serverType: options.serverType,
+    packageManager: options.packageManager,
+    versions: packageVersions,
+  };
+
+  for (const file of files) {
+    const srcPath = path.join(templatePath, file);
+
+    const stat = await fs.stat(srcPath);
+
+    if (stat.isDirectory()) {
+      const destPath = path.join(targetPath, file);
+      await copyTemplate(srcPath, destPath, options);
+    } else if (file.endsWith(".template")) {
+      // Process template files with EJS
+      const content = await fs.readFile(srcPath, "utf8");
+      const rendered = ejs.render(content, ejsData);
+
+      // Remove .template extension from destination filename
+      const destFileName = path.basename(file, ".template");
+      const destPath = path.join(targetPath, destFileName);
+
+      await fs.writeFile(destPath, rendered);
+    } else {
+      // Copy non-template files as-is
+      const destPath = path.join(targetPath, file);
+      await fs.copyFile(srcPath, destPath);
+    }
+  }
+}
+
+async function main() {
+  console.clear();
+
+  p.intro(pc.bgCyan(pc.black(" create-modelfetch ")));
+
+  const projectName = await p.text({
+    message: "What is your project named?",
+    placeholder: "my-mcp-server",
+    defaultValue: "my-mcp-server",
+    validate: validateProjectName,
+  });
+
+  if (p.isCancel(projectName)) {
+    p.cancel("Operation cancelled.");
+    process.exit(0);
+  }
+
+  // Generate default title from project name
+  const defaultTitle = projectName
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+
+  const projectTitle = await p.text({
+    message: "What is your project title?",
+    placeholder: defaultTitle,
+    defaultValue: defaultTitle,
+  });
+
+  if (p.isCancel(projectTitle)) {
+    p.cancel("Operation cancelled.");
+    process.exit(0);
+  }
+
+  const runtime = (await p.select({
+    message: "Which runtime would you like to use?",
+    options: [
+      { value: "node", label: "Node.js", hint: "Universal JavaScript runtime" },
+      {
+        value: "bun",
+        label: "Bun",
+        hint: "Fast all-in-one JavaScript runtime",
+      },
+      {
+        value: "deno",
+        label: "Deno",
+        hint: "Secure runtime for JavaScript and TypeScript",
+      },
+    ],
+  })) as Runtime;
+
+  if (p.isCancel(runtime)) {
+    p.cancel("Operation cancelled.");
+    process.exit(0);
+  }
+
+  const language = (await p.select({
+    message: "Which language would you like to use?",
+    options: [
+      {
+        value: "typescript",
+        label: "TypeScript",
+        hint: "Recommended for better type safety",
+      },
+      { value: "javascript", label: "JavaScript" },
+    ],
+  })) as Language;
+
+  if (p.isCancel(language)) {
+    p.cancel("Operation cancelled.");
+    process.exit(0);
+  }
+
+  const serverType = (await p.select({
+    message: "What type of MCP server would you like to create?",
+    options: [
+      {
+        value: "tools",
+        label: "Tools",
+        hint: "Provide tools/functions to LLMs",
+      },
+      {
+        value: "resources",
+        label: "Resources",
+        hint: "Expose data and content to LLMs",
+      },
+      {
+        value: "prompts",
+        label: "Prompts",
+        hint: "Provide reusable prompts to LLMs",
+      },
+      {
+        value: "hybrid",
+        label: "Hybrid",
+        hint: "Combine tools, resources, and prompts",
+      },
+    ],
+  })) as ServerType;
+
+  if (p.isCancel(serverType)) {
+    p.cancel("Operation cancelled.");
+    process.exit(0);
+  }
+
+  const detectedPM = await detectPackageManager();
+  const packageManager = (await p.select({
+    message: "Which package manager would you like to use?",
+    options: [
+      { value: "npm", label: "npm" },
+      { value: "pnpm", label: "pnpm" },
+      { value: "yarn", label: "yarn" },
+      { value: "bun", label: "bun" },
+    ],
+    initialValue: detectedPM,
+  })) as PackageManager;
+
+  if (p.isCancel(packageManager)) {
+    p.cancel("Operation cancelled.");
+    process.exit(0);
+  }
+
+  const installDeps = await p.confirm({
+    message: "Would you like to install dependencies?",
+    initialValue: true,
+  });
+
+  if (p.isCancel(installDeps)) {
+    p.cancel("Operation cancelled.");
+    process.exit(0);
+  }
+
+  const options: ProjectOptions = {
+    name: projectName,
+    title: projectTitle,
+    runtime,
+    language,
+    serverType,
+    packageManager,
+    installDeps,
+  };
+
+  const s = p.spinner();
+
+  s.start("Creating your MCP server");
+
+  const targetDir = path.resolve(projectName);
+  const templateName = `${runtime}-${language === "javascript" ? "js" : "ts"}`;
+  const templateDir = new URL(`../templates/${templateName}`, import.meta.url)
+    .pathname;
+
+  try {
+    // Check if directory exists
+    try {
+      await fs.access(targetDir);
+      const overwrite = await p.confirm({
+        message: `Directory ${projectName} already exists. Overwrite?`,
+        initialValue: false,
+      });
+
+      if (!overwrite || p.isCancel(overwrite)) {
+        p.cancel("Operation cancelled.");
+        process.exit(0);
+      }
+
+      await fs.rm(targetDir, { recursive: true });
+    } catch {
+      // Directory doesn't exist, proceed with creation
+    }
+
+    // Copy template
+    await copyTemplate(templateDir, targetDir, options);
+
+    s.stop("Project created!");
+
+    // Install dependencies
+    if (installDeps) {
+      s.start("Installing dependencies");
+
+      const installCommand = {
+        npm: "npm install",
+        pnpm: "pnpm install",
+        yarn: "yarn install",
+        bun: "bun install",
+      }[packageManager];
+
+      await execAsync(installCommand, { cwd: targetDir });
+
+      s.stop("Dependencies installed!");
+    }
+
+    p.outro(pc.green("Your MCP server is ready!"));
+
+    console.log();
+    console.log(pc.bold("Next steps:"));
+    console.log();
+    console.log(pc.gray("  Navigate to your project:"));
+    console.log(`  ${pc.cyan(`cd ${projectName}`)}`);
+    console.log();
+    console.log(pc.gray("  Start the MCP server:"));
+    console.log(`  ${pc.cyan(`${packageManager} start`)}`);
+    console.log();
+    console.log(pc.gray("  Test with MCP Inspector:"));
+    console.log(`  ${pc.cyan("npx @modelcontextprotocol/inspector")}`);
+    console.log();
+    console.log(pc.gray("  Read the documentation:"));
+    console.log(`  ${pc.cyan("https://www.modelfetch.com/docs")}`);
+    console.log();
+  } catch (error) {
+    s.stop("Failed to create project");
+    console.error(pc.red("Error:"), error);
+    process.exit(1);
+  }
+}
+
+try {
+  await main();
+} catch (error: unknown) {
+  console.error(pc.red("Unexpected error:"), error);
+  process.exit(1);
+}

--- a/libs/create-modelfetch/src/index.ts
+++ b/libs/create-modelfetch/src/index.ts
@@ -283,7 +283,7 @@ async function main() {
     console.log(`  ${pc.cyan("npx @modelcontextprotocol/inspector")}`);
     console.log();
     console.log(pc.gray("  Read the documentation:"));
-    console.log(`  ${pc.cyan("https://www.modelfetch.com/docs")}`);
+    console.log(`  ${pc.cyan("https://preview.modelfetch.com/docs")}`);
     console.log();
   } catch (error) {
     s.stop("Failed to create project");

--- a/libs/create-modelfetch/templates/bun-js/README.md.template
+++ b/libs/create-modelfetch/templates/bun-js/README.md.template
@@ -9,7 +9,7 @@ An MCP (Model Context Protocol) server built with [ModelFetch](https://www.model
 Start the MCP server:
 
 ```bash
-<%= packageManager %> start
+bun start
 ```
 
 ### Testing with MCP Inspector

--- a/libs/create-modelfetch/templates/bun-js/README.md.template
+++ b/libs/create-modelfetch/templates/bun-js/README.md.template
@@ -1,6 +1,6 @@
 # <%= projectTitle %>
 
-An MCP (Model Context Protocol) server built with [ModelFetch](https://www.modelfetch.com).
+An MCP (Model Context Protocol) server built with [ModelFetch](https://preview.modelfetch.com).
 
 ## Quick Start
 
@@ -111,6 +111,6 @@ server.prompt(
 ## Learn More
 
 - [Model Context Protocol](https://modelcontextprotocol.io)
-- [ModelFetch Website](https://www.modelfetch.com)
-- [ModelFetch Documentation](https://www.modelfetch.com/docs)
+- [ModelFetch Website](https://preview.modelfetch.com)
+- [ModelFetch Documentation](https://preview.modelfetch.com/docs)
 - [ModelFetch GitHub](https://github.com/phuctm97/modelfetch)

--- a/libs/create-modelfetch/templates/bun-js/package.json.template
+++ b/libs/create-modelfetch/templates/bun-js/package.json.template
@@ -1,0 +1,15 @@
+{
+  "name": "<%= projectName %>",
+  "version": "0.0.1",
+  "description": "<%= projectTitle %> (built with ModelFetch)",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "bun run ./src/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "<%= versions['@modelcontextprotocol/sdk'] %>",
+    "@modelfetch/bun": "<%= versions['@modelfetch/bun'] %>",
+    "zod": "<%= versions['zod'] %>"
+  }
+}

--- a/libs/create-modelfetch/templates/bun-js/src/index.js.template
+++ b/libs/create-modelfetch/templates/bun-js/src/index.js.template
@@ -1,0 +1,7 @@
+import handle, { getEndpoint } from "@modelfetch/bun";
+
+import server from "./server.js";
+
+handle(server, (address) => {
+  console.log(`MCP server is available at ${getEndpoint(address)}`);
+});

--- a/libs/create-modelfetch/templates/bun-js/src/server.js.template
+++ b/libs/create-modelfetch/templates/bun-js/src/server.js.template
@@ -1,0 +1,80 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import packageJson from "../package.json" with { type: "json" };
+
+const server = new McpServer({
+  title: "<%= projectTitle %>",
+  name: packageJson.name,
+  version: packageJson.version,
+});
+
+// Example tool: Roll dice
+server.tool(
+  "roll_dice",
+  "Rolls an N-sided dice",
+  { sides: z.number().int().min(2).describe("Number of sides on the dice") },
+  ({ sides }) => ({
+    content: [
+      {
+        type: "text",
+        text: `🎲 You rolled a ${1 + Math.floor(Math.random() * sides)}!`,
+      },
+    ],
+  }),
+);
+
+// Example resource: Get current time
+server.resource(
+  "time://current",
+  async () => {
+    const now = new Date();
+    return {
+      contents: [
+        {
+          uri: "time://current",
+          mimeType: "text/plain",
+          text: `Current time: ${now.toISOString()}`,
+        },
+      ],
+    };
+  },
+  "Get the current time in ISO format",
+);
+
+// Example prompt: Generate greeting
+server.prompt(
+  "greeting",
+  "Generate a personalized greeting",
+  [
+    {
+      name: "name",
+      description: "Name of the person to greet",
+      required: true,
+    },
+    {
+      name: "style",
+      description: "Style of greeting (formal/casual)",
+      required: false,
+    },
+  ],
+  ({ name, style = "casual" }) => {
+    const greeting = style === "formal" 
+      ? `Good day, ${name}. How may I assist you today?`
+      : `Hey ${name}! What's up?`;
+    
+    return {
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: greeting,
+          },
+        },
+      ],
+    };
+  },
+);
+
+export default server;

--- a/libs/create-modelfetch/templates/bun-ts/README.md.template
+++ b/libs/create-modelfetch/templates/bun-ts/README.md.template
@@ -1,6 +1,6 @@
 # <%= projectTitle %>
 
-An MCP (Model Context Protocol) server built with [ModelFetch](https://www.modelfetch.com).
+An MCP (Model Context Protocol) server built with [ModelFetch](https://preview.modelfetch.com).
 
 ## Quick Start
 
@@ -111,6 +111,6 @@ server.prompt(
 ## Learn More
 
 - [Model Context Protocol](https://modelcontextprotocol.io)
-- [ModelFetch Website](https://www.modelfetch.com)
-- [ModelFetch Documentation](https://www.modelfetch.com/docs)
+- [ModelFetch Website](https://preview.modelfetch.com)
+- [ModelFetch Documentation](https://preview.modelfetch.com/docs)
 - [ModelFetch GitHub](https://github.com/phuctm97/modelfetch)

--- a/libs/create-modelfetch/templates/bun-ts/README.md.template
+++ b/libs/create-modelfetch/templates/bun-ts/README.md.template
@@ -9,7 +9,7 @@ An MCP (Model Context Protocol) server built with [ModelFetch](https://www.model
 Start the MCP server:
 
 ```bash
-<%= packageManager %> start
+bun start
 ```
 
 ### Testing with MCP Inspector
@@ -27,8 +27,8 @@ Then connect to your server at `http://localhost:3000` (or the port shown in you
 ```
 <%= projectName %>/
 ├── src/
-│   ├── index.js      # Project entry point
-│   └── server.js     # MCP server implementation
+│   ├── index.ts      # Project entry point
+│   └── server.ts     # MCP server implementation
 ├── package.json
 └── README.md
 ```
@@ -39,7 +39,7 @@ Then connect to your server at `http://localhost:3000` (or the port shown in you
 
 Tools allow your MCP server to provide executable functions to LLMs:
 
-```javascript
+```typescript
 server.tool(
   "my_tool",
   "What this tool does",
@@ -61,7 +61,7 @@ server.tool(
 
 Resources expose data and content to LLMs:
 
-```javascript
+```typescript
 server.resource(
   "resource://my-resource", 
   async () => {
@@ -83,7 +83,7 @@ server.resource(
 
 Prompts provide reusable prompt templates:
 
-```javascript
+```typescript
 server.prompt(
   "my_prompt",
   "What this prompt does",

--- a/libs/create-modelfetch/templates/bun-ts/package.json.template
+++ b/libs/create-modelfetch/templates/bun-ts/package.json.template
@@ -4,19 +4,15 @@
   "description": "<%= projectTitle %> (built with ModelFetch)",
   "private": true,
   "type": "module",
-  "main": "./src/index.ts",
   "scripts": {
-    "start": "tsx ."
+    "start": "bun run ./src/index.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "<%= versions['@modelcontextprotocol/sdk'] %>",
-    "@modelfetch/node": "<%= versions['@modelfetch/node'] %>",
-    "tslib": "<%= versions['tslib'] %>",
+    "@modelfetch/bun": "<%= versions['@modelfetch/bun'] %>",
     "zod": "<%= versions['zod'] %>"
   },
   "devDependencies": {
-    "@types/node": "<%= versions['@types/node'] %>",
-    "tsx": "<%= versions['tsx'] %>",
-    "typescript": "<%= versions['typescript'] %>"
+    "@types/bun": "<%= versions['@types/bun'] %>"
   }
 }

--- a/libs/create-modelfetch/templates/bun-ts/src/index.ts.template
+++ b/libs/create-modelfetch/templates/bun-ts/src/index.ts.template
@@ -1,0 +1,7 @@
+import handle, { getEndpoint } from "@modelfetch/bun";
+
+import server from "./server.ts";
+
+handle(server, (address) => {
+  console.log(`MCP server is available at ${getEndpoint(address)}`);
+});

--- a/libs/create-modelfetch/templates/bun-ts/src/server.ts.template
+++ b/libs/create-modelfetch/templates/bun-ts/src/server.ts.template
@@ -1,0 +1,80 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import packageJson from "../package.json" with { type: "json" };
+
+const server = new McpServer({
+  title: "<%= projectTitle %>",
+  name: packageJson.name,
+  version: packageJson.version,
+});
+
+// Example tool: Roll dice
+server.tool(
+  "roll_dice",
+  "Rolls an N-sided dice",
+  { sides: z.number().int().min(2).describe("Number of sides on the dice") },
+  ({ sides }) => ({
+    content: [
+      {
+        type: "text",
+        text: `🎲 You rolled a ${1 + Math.floor(Math.random() * sides)}!`,
+      },
+    ],
+  }),
+);
+
+// Example resource: Get current time
+server.resource(
+  "time://current",
+  async () => {
+    const now = new Date();
+    return {
+      contents: [
+        {
+          uri: "time://current",
+          mimeType: "text/plain",
+          text: `Current time: ${now.toISOString()}`,
+        },
+      ],
+    };
+  },
+  "Get the current time in ISO format",
+);
+
+// Example prompt: Generate greeting
+server.prompt(
+  "greeting",
+  "Generate a personalized greeting",
+  [
+    {
+      name: "name",
+      description: "Name of the person to greet",
+      required: true,
+    },
+    {
+      name: "style",
+      description: "Style of greeting (formal/casual)",
+      required: false,
+    },
+  ],
+  ({ name, style = "casual" }) => {
+    const greeting = style === "formal" 
+      ? `Good day, ${name}. How may I assist you today?`
+      : `Hey ${name}! What's up?`;
+    
+    return {
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: greeting,
+          },
+        },
+      ],
+    };
+  },
+);
+
+export default server;

--- a/libs/create-modelfetch/templates/deno-js/README.md.template
+++ b/libs/create-modelfetch/templates/deno-js/README.md.template
@@ -9,7 +9,7 @@ An MCP (Model Context Protocol) server built with [ModelFetch](https://www.model
 Start the MCP server:
 
 ```bash
-<%= packageManager %> start
+deno task start
 ```
 
 ### Testing with MCP Inspector
@@ -29,7 +29,7 @@ Then connect to your server at `http://localhost:3000` (or the port shown in you
 ├── src/
 │   ├── index.js      # Project entry point
 │   └── server.js     # MCP server implementation
-├── package.json
+├── deno.json
 └── README.md
 ```
 

--- a/libs/create-modelfetch/templates/deno-js/README.md.template
+++ b/libs/create-modelfetch/templates/deno-js/README.md.template
@@ -1,6 +1,6 @@
 # <%= projectTitle %>
 
-An MCP (Model Context Protocol) server built with [ModelFetch](https://www.modelfetch.com).
+An MCP (Model Context Protocol) server built with [ModelFetch](https://preview.modelfetch.com).
 
 ## Quick Start
 
@@ -111,6 +111,6 @@ server.prompt(
 ## Learn More
 
 - [Model Context Protocol](https://modelcontextprotocol.io)
-- [ModelFetch Website](https://www.modelfetch.com)
-- [ModelFetch Documentation](https://www.modelfetch.com/docs)
+- [ModelFetch Website](https://preview.modelfetch.com)
+- [ModelFetch Documentation](https://preview.modelfetch.com/docs)
 - [ModelFetch GitHub](https://github.com/phuctm97/modelfetch)

--- a/libs/create-modelfetch/templates/deno-js/deno.json.template
+++ b/libs/create-modelfetch/templates/deno-js/deno.json.template
@@ -1,0 +1,12 @@
+{
+  "name": "<%= projectName %>",
+  "version": "0.0.1",
+  "imports": {
+    "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@<%= versions['@modelcontextprotocol/sdk'] %>",
+    "@modelfetch/deno": "npm:@modelfetch/deno@<%= versions['@modelfetch/deno'] %>",
+    "zod": "npm:zod@<%= versions['zod'] %>"
+  },
+  "tasks": {
+    "start": "deno run -A ./src/index.js"
+  }
+}

--- a/libs/create-modelfetch/templates/deno-js/src/index.js.template
+++ b/libs/create-modelfetch/templates/deno-js/src/index.js.template
@@ -1,0 +1,7 @@
+import handle, { getEndpoint } from "@modelfetch/deno";
+
+import server from "./server.js";
+
+handle(server, (address) => {
+  console.log(`MCP server is available at ${getEndpoint(address)}`);
+});

--- a/libs/create-modelfetch/templates/deno-js/src/server.js.template
+++ b/libs/create-modelfetch/templates/deno-js/src/server.js.template
@@ -1,0 +1,80 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import denoJson from "../deno.json" with { type: "json" };
+
+const server = new McpServer({
+  title: "<%= projectTitle %>",
+  name: denoJson.name,
+  version: denoJson.version,
+});
+
+// Example tool: Roll dice
+server.tool(
+  "roll_dice",
+  "Rolls an N-sided dice",
+  { sides: z.number().int().min(2).describe("Number of sides on the dice") },
+  ({ sides }) => ({
+    content: [
+      {
+        type: "text",
+        text: `🎲 You rolled a ${1 + Math.floor(Math.random() * sides)}!`,
+      },
+    ],
+  }),
+);
+
+// Example resource: Get current time
+server.resource(
+  "time://current",
+  async () => {
+    const now = new Date();
+    return {
+      contents: [
+        {
+          uri: "time://current",
+          mimeType: "text/plain",
+          text: `Current time: ${now.toISOString()}`,
+        },
+      ],
+    };
+  },
+  "Get the current time in ISO format",
+);
+
+// Example prompt: Generate greeting
+server.prompt(
+  "greeting",
+  "Generate a personalized greeting",
+  [
+    {
+      name: "name",
+      description: "Name of the person to greet",
+      required: true,
+    },
+    {
+      name: "style",
+      description: "Style of greeting (formal/casual)",
+      required: false,
+    },
+  ],
+  ({ name, style = "casual" }) => {
+    const greeting = style === "formal" 
+      ? `Good day, ${name}. How may I assist you today?`
+      : `Hey ${name}! What's up?`;
+    
+    return {
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: greeting,
+          },
+        },
+      ],
+    };
+  },
+);
+
+export default server;

--- a/libs/create-modelfetch/templates/deno-ts/README.md.template
+++ b/libs/create-modelfetch/templates/deno-ts/README.md.template
@@ -1,6 +1,6 @@
 # <%= projectTitle %>
 
-An MCP (Model Context Protocol) server built with [ModelFetch](https://www.modelfetch.com).
+An MCP (Model Context Protocol) server built with [ModelFetch](https://preview.modelfetch.com).
 
 ## Quick Start
 
@@ -111,6 +111,6 @@ server.prompt(
 ## Learn More
 
 - [Model Context Protocol](https://modelcontextprotocol.io)
-- [ModelFetch Website](https://www.modelfetch.com)
-- [ModelFetch Documentation](https://www.modelfetch.com/docs)
+- [ModelFetch Website](https://preview.modelfetch.com)
+- [ModelFetch Documentation](https://preview.modelfetch.com/docs)
 - [ModelFetch GitHub](https://github.com/phuctm97/modelfetch)

--- a/libs/create-modelfetch/templates/deno-ts/README.md.template
+++ b/libs/create-modelfetch/templates/deno-ts/README.md.template
@@ -9,7 +9,7 @@ An MCP (Model Context Protocol) server built with [ModelFetch](https://www.model
 Start the MCP server:
 
 ```bash
-<%= packageManager %> start
+deno task start
 ```
 
 ### Testing with MCP Inspector
@@ -27,9 +27,9 @@ Then connect to your server at `http://localhost:3000` (or the port shown in you
 ```
 <%= projectName %>/
 ├── src/
-│   ├── index.js      # Project entry point
-│   └── server.js     # MCP server implementation
-├── package.json
+│   ├── index.ts      # Project entry point
+│   └── server.ts     # MCP server implementation
+├── deno.json
 └── README.md
 ```
 
@@ -39,7 +39,7 @@ Then connect to your server at `http://localhost:3000` (or the port shown in you
 
 Tools allow your MCP server to provide executable functions to LLMs:
 
-```javascript
+```typescript
 server.tool(
   "my_tool",
   "What this tool does",
@@ -61,7 +61,7 @@ server.tool(
 
 Resources expose data and content to LLMs:
 
-```javascript
+```typescript
 server.resource(
   "resource://my-resource", 
   async () => {
@@ -83,7 +83,7 @@ server.resource(
 
 Prompts provide reusable prompt templates:
 
-```javascript
+```typescript
 server.prompt(
   "my_prompt",
   "What this prompt does",

--- a/libs/create-modelfetch/templates/deno-ts/deno.json.template
+++ b/libs/create-modelfetch/templates/deno-ts/deno.json.template
@@ -1,0 +1,12 @@
+{
+  "name": "<%= projectName %>",
+  "version": "0.0.1",
+  "imports": {
+    "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@<%= versions['@modelcontextprotocol/sdk'] %>",
+    "@modelfetch/deno": "npm:@modelfetch/deno@<%= versions['@modelfetch/deno'] %>",
+    "zod": "npm:zod@<%= versions['zod'] %>"
+  },
+  "tasks": {
+    "start": "deno run -A ./src/index.ts"
+  }
+}

--- a/libs/create-modelfetch/templates/deno-ts/src/index.ts.template
+++ b/libs/create-modelfetch/templates/deno-ts/src/index.ts.template
@@ -1,0 +1,7 @@
+import handle, { getEndpoint } from "@modelfetch/deno";
+
+import server from "./server.ts";
+
+handle(server, (address) => {
+  console.log(`MCP server is available at ${getEndpoint(address)}`);
+});

--- a/libs/create-modelfetch/templates/deno-ts/src/server.ts.template
+++ b/libs/create-modelfetch/templates/deno-ts/src/server.ts.template
@@ -1,0 +1,80 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import denoJson from "../deno.json" with { type: "json" };
+
+const server = new McpServer({
+  title: "<%= projectTitle %>",
+  name: denoJson.name,
+  version: denoJson.version,
+});
+
+// Example tool: Roll dice
+server.tool(
+  "roll_dice",
+  "Rolls an N-sided dice",
+  { sides: z.number().int().min(2).describe("Number of sides on the dice") },
+  ({ sides }) => ({
+    content: [
+      {
+        type: "text",
+        text: `🎲 You rolled a ${1 + Math.floor(Math.random() * sides)}!`,
+      },
+    ],
+  }),
+);
+
+// Example resource: Get current time
+server.resource(
+  "time://current",
+  async () => {
+    const now = new Date();
+    return {
+      contents: [
+        {
+          uri: "time://current",
+          mimeType: "text/plain",
+          text: `Current time: ${now.toISOString()}`,
+        },
+      ],
+    };
+  },
+  "Get the current time in ISO format",
+);
+
+// Example prompt: Generate greeting
+server.prompt(
+  "greeting",
+  "Generate a personalized greeting",
+  [
+    {
+      name: "name",
+      description: "Name of the person to greet",
+      required: true,
+    },
+    {
+      name: "style",
+      description: "Style of greeting (formal/casual)",
+      required: false,
+    },
+  ],
+  ({ name, style = "casual" }) => {
+    const greeting = style === "formal" 
+      ? `Good day, ${name}. How may I assist you today?`
+      : `Hey ${name}! What's up?`;
+    
+    return {
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: greeting,
+          },
+        },
+      ],
+    };
+  },
+);
+
+export default server;

--- a/libs/create-modelfetch/templates/node-js/.gitignore.template
+++ b/libs/create-modelfetch/templates/node-js/.gitignore.template
@@ -1,0 +1,3 @@
+.DS_Store
+node_modules
+dist

--- a/libs/create-modelfetch/templates/node-js/README.md.template
+++ b/libs/create-modelfetch/templates/node-js/README.md.template
@@ -35,7 +35,7 @@ Run the server:
 ```
 <%= projectName %>/
 ├── src/
-│   ├── index.js      # Server entry point
+│   ├── index.js      # Project entry point
 │   └── server.js     # MCP server implementation
 ├── package.json
 └── README.md

--- a/libs/create-modelfetch/templates/node-js/README.md.template
+++ b/libs/create-modelfetch/templates/node-js/README.md.template
@@ -1,6 +1,6 @@
 # <%= projectTitle %>
 
-An MCP (Model Context Protocol) server built with [ModelFetch](https://www.modelfetch.com).
+An MCP (Model Context Protocol) server built with [ModelFetch](https://preview.modelfetch.com).
 
 ## Quick Start
 
@@ -111,6 +111,6 @@ server.prompt(
 ## Learn More
 
 - [Model Context Protocol](https://modelcontextprotocol.io)
-- [ModelFetch Website](https://www.modelfetch.com)
-- [ModelFetch Documentation](https://www.modelfetch.com/docs)
+- [ModelFetch Website](https://preview.modelfetch.com)
+- [ModelFetch Documentation](https://preview.modelfetch.com/docs)
 - [ModelFetch GitHub](https://github.com/phuctm97/modelfetch)

--- a/libs/create-modelfetch/templates/node-js/README.md.template
+++ b/libs/create-modelfetch/templates/node-js/README.md.template
@@ -1,0 +1,124 @@
+# <%= projectTitle %>
+
+An MCP (Model Context Protocol) server built with [ModelFetch](https://www.modelfetch.com).
+
+## Quick Start
+
+### Running the Server
+
+Start the MCP server:
+
+```bash
+<%= packageManager %> start
+```
+
+### Testing with MCP Inspector
+
+In a separate terminal, run the MCP Inspector to test your server:
+
+```bash
+npx @modelcontextprotocol/inspector
+```
+
+Then connect to your server at `http://localhost:3000` (or the port shown in your dev server output).
+
+### Running in Production
+
+Run the server:
+
+```bash
+<%= packageManager %> start
+```
+
+## Project Structure
+
+```
+<%= projectName %>/
+├── src/
+│   ├── index.js      # Server entry point
+│   └── server.js     # MCP server implementation
+├── package.json
+└── README.md
+```
+
+## Adding Features
+
+### Tools
+
+Tools allow your MCP server to provide executable functions to LLMs:
+
+```javascript
+server.tool(
+  "my_tool",
+  "What this tool does",
+  { 
+    param: z.string().describe("Parameter description") 
+  },
+  ({ param }) => ({
+    content: [
+      {
+        type: "text",
+        text: `Result: ${param}`,
+      },
+    ],
+  }),
+);
+```
+
+### Resources
+
+Resources expose data and content to LLMs:
+
+```javascript
+server.resource(
+  "resource://my-resource", 
+  async () => {
+    return {
+      contents: [
+        {
+          uri: "resource://my-resource",
+          mimeType: "text/plain",
+          text: "Resource content",
+        },
+      ],
+    };
+  },
+  "What this resource provides",
+);
+```
+
+### Prompts
+
+Prompts provide reusable prompt templates:
+
+```javascript
+server.prompt(
+  "my_prompt",
+  "What this prompt does",
+  [
+    { 
+      name: "arg", 
+      description: "Argument description", 
+      required: true 
+    },
+  ],
+  ({ arg }) => ({
+    messages: [
+      {
+        role: "user",
+        content: { 
+          type: "text", 
+          text: `Prompt with ${arg}` 
+        },
+      },
+    ],
+  }),
+);
+```
+
+## Learn More
+
+- [Model Context Protocol](https://modelcontextprotocol.io)
+- [ModelFetch Website](https://www.modelfetch.com)
+- [ModelFetch Documentation](https://www.modelfetch.com/docs)
+- [ModelFetch GitHub](https://github.com/phuctm97/modelfetch)

--- a/libs/create-modelfetch/templates/node-js/package.json.template
+++ b/libs/create-modelfetch/templates/node-js/package.json.template
@@ -1,0 +1,16 @@
+{
+  "name": "<%= projectName %>",
+  "version": "0.0.1",
+  "description": "<%= projectTitle %> (built with ModelFetch)",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.js",
+  "scripts": {
+    "start": "node ."
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "<%= versions['@modelcontextprotocol/sdk'] %>",
+    "@modelfetch/node": "<%= versions['@modelfetch/node'] %>",
+    "zod": "<%= versions['zod'] %>"
+  }
+}

--- a/libs/create-modelfetch/templates/node-js/src/index.js.template
+++ b/libs/create-modelfetch/templates/node-js/src/index.js.template
@@ -1,0 +1,7 @@
+import handle, { getEndpoint } from "@modelfetch/node";
+
+import server from "./server.js";
+
+handle(server, (address) => {
+  console.log(`MCP server is available at ${getEndpoint(address)}`);
+});

--- a/libs/create-modelfetch/templates/node-js/src/server.js.template
+++ b/libs/create-modelfetch/templates/node-js/src/server.js.template
@@ -1,0 +1,80 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import packageJson from "../package.json" with { type: "json" };
+
+const server = new McpServer({
+  title: "<%= projectTitle %>",
+  name: packageJson.name,
+  version: packageJson.version,
+});
+
+// Example tool: Roll dice
+server.tool(
+  "roll_dice",
+  "Rolls an N-sided dice",
+  { sides: z.number().int().min(2).describe("Number of sides on the dice") },
+  ({ sides }) => ({
+    content: [
+      {
+        type: "text",
+        text: `🎲 You rolled a ${1 + Math.floor(Math.random() * sides)}!`,
+      },
+    ],
+  }),
+);
+
+// Example resource: Get current time
+server.resource(
+  "time://current",
+  async () => {
+    const now = new Date();
+    return {
+      contents: [
+        {
+          uri: "time://current",
+          mimeType: "text/plain",
+          text: `Current time: ${now.toISOString()}`,
+        },
+      ],
+    };
+  },
+  "Get the current time in ISO format",
+);
+
+// Example prompt: Generate greeting
+server.prompt(
+  "greeting",
+  "Generate a personalized greeting",
+  [
+    {
+      name: "name",
+      description: "Name of the person to greet",
+      required: true,
+    },
+    {
+      name: "style",
+      description: "Style of greeting (formal/casual)",
+      required: false,
+    },
+  ],
+  ({ name, style = "casual" }) => {
+    const greeting = style === "formal" 
+      ? `Good day, ${name}. How may I assist you today?`
+      : `Hey ${name}! What's up?`;
+    
+    return {
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: greeting,
+          },
+        },
+      ],
+    };
+  },
+);
+
+export default server;

--- a/libs/create-modelfetch/templates/node-ts/.gitignore.template
+++ b/libs/create-modelfetch/templates/node-ts/.gitignore.template
@@ -1,0 +1,4 @@
+.DS_Store
+*.tsbuildinfo
+node_modules
+dist

--- a/libs/create-modelfetch/templates/node-ts/README.md.template
+++ b/libs/create-modelfetch/templates/node-ts/README.md.template
@@ -1,0 +1,117 @@
+# <%= projectTitle %>
+
+An MCP (Model Context Protocol) server built with [ModelFetch](https://www.modelfetch.com).
+
+## Quick Start
+
+### Running the Server
+
+Start the MCP server:
+
+```bash
+<%= packageManager %> start
+```
+
+### Testing with MCP Inspector
+
+In a separate terminal, run the MCP Inspector to test your server:
+
+```bash
+npx @modelcontextprotocol/inspector
+```
+
+Then connect to your server at `http://localhost:3000` (or the port shown in your dev server output).
+
+## Project Structure
+
+```
+<%= projectName %>/
+├── src/
+│   ├── index.ts      # Server entry point
+│   └── server.ts     # MCP server implementation
+├── package.json
+├── tsconfig.json
+└── README.md
+```
+
+## Adding Features
+
+### Tools
+
+Tools allow your MCP server to provide executable functions to LLMs:
+
+```typescript
+server.tool(
+  "my_tool",
+  "What this tool does",
+  { 
+    param: z.string().describe("Parameter description") 
+  },
+  ({ param }) => ({
+    content: [
+      {
+        type: "text",
+        text: `Result: ${param}`,
+      },
+    ],
+  }),
+);
+```
+
+### Resources
+
+Resources expose data and content to LLMs:
+
+```typescript
+server.resource(
+  "resource://my-resource", 
+  async () => {
+    return {
+      contents: [
+        {
+          uri: "resource://my-resource",
+          mimeType: "text/plain",
+          text: "Resource content",
+        },
+      ],
+    };
+  },
+  "What this resource provides",
+);
+```
+
+### Prompts
+
+Prompts provide reusable prompt templates:
+
+```typescript
+server.prompt(
+  "my_prompt",
+  "What this prompt does",
+  [
+    { 
+      name: "arg", 
+      description: "Argument description", 
+      required: true 
+    },
+  ],
+  ({ arg }) => ({
+    messages: [
+      {
+        role: "user",
+        content: { 
+          type: "text", 
+          text: `Prompt with ${arg}` 
+        },
+      },
+    ],
+  }),
+);
+```
+
+## Learn More
+
+- [Model Context Protocol](https://modelcontextprotocol.io)
+- [ModelFetch Website](https://www.modelfetch.com)
+- [ModelFetch Documentation](https://www.modelfetch.com/docs)
+- [ModelFetch GitHub](https://github.com/phuctm97/modelfetch)

--- a/libs/create-modelfetch/templates/node-ts/README.md.template
+++ b/libs/create-modelfetch/templates/node-ts/README.md.template
@@ -27,7 +27,7 @@ Then connect to your server at `http://localhost:3000` (or the port shown in you
 ```
 <%= projectName %>/
 ├── src/
-│   ├── index.ts      # Server entry point
+│   ├── index.ts      # Project entry point
 │   └── server.ts     # MCP server implementation
 ├── package.json
 ├── tsconfig.json

--- a/libs/create-modelfetch/templates/node-ts/README.md.template
+++ b/libs/create-modelfetch/templates/node-ts/README.md.template
@@ -1,6 +1,6 @@
 # <%= projectTitle %>
 
-An MCP (Model Context Protocol) server built with [ModelFetch](https://www.modelfetch.com).
+An MCP (Model Context Protocol) server built with [ModelFetch](https://preview.modelfetch.com).
 
 ## Quick Start
 
@@ -112,6 +112,6 @@ server.prompt(
 ## Learn More
 
 - [Model Context Protocol](https://modelcontextprotocol.io)
-- [ModelFetch Website](https://www.modelfetch.com)
-- [ModelFetch Documentation](https://www.modelfetch.com/docs)
+- [ModelFetch Website](https://preview.modelfetch.com)
+- [ModelFetch Documentation](https://preview.modelfetch.com/docs)
 - [ModelFetch GitHub](https://github.com/phuctm97/modelfetch)

--- a/libs/create-modelfetch/templates/node-ts/package.json.template
+++ b/libs/create-modelfetch/templates/node-ts/package.json.template
@@ -1,0 +1,20 @@
+{
+  "name": "<%= projectName %>",
+  "version": "0.0.1",
+  "description": "<%= projectTitle %> (built with ModelFetch)",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "scripts": {
+    "start": "tsx ."
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "<%= versions['@modelcontextprotocol/sdk'] %>",
+    "@modelfetch/node": "<%= versions['@modelfetch/node'] %>",
+    "tslib": "<%= versions['tslib'] %>",
+    "zod": "<%= versions['zod'] %>"
+  },
+  "devDependencies": {
+    "tsx": "<%= versions['tsx'] %>"
+  }
+}

--- a/libs/create-modelfetch/templates/node-ts/src/index.ts.template
+++ b/libs/create-modelfetch/templates/node-ts/src/index.ts.template
@@ -1,0 +1,7 @@
+import handle, { getEndpoint } from "@modelfetch/node";
+
+import server from "./server";
+
+handle(server, (address) => {
+  console.log(`MCP server is available at ${getEndpoint(address)}`);
+});

--- a/libs/create-modelfetch/templates/node-ts/src/server.ts.template
+++ b/libs/create-modelfetch/templates/node-ts/src/server.ts.template
@@ -1,0 +1,80 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import packageJson from "../package.json" with { type: "json" };
+
+const server = new McpServer({
+  title: "<%= projectTitle %>",
+  name: packageJson.name,
+  version: packageJson.version,
+});
+
+// Example tool: Roll dice
+server.tool(
+  "roll_dice",
+  "Rolls an N-sided dice",
+  { sides: z.number().int().min(2).describe("Number of sides on the dice") },
+  ({ sides }) => ({
+    content: [
+      {
+        type: "text",
+        text: `🎲 You rolled a ${1 + Math.floor(Math.random() * sides)}!`,
+      },
+    ],
+  }),
+);
+
+// Example resource: Get current time
+server.resource(
+  "time://current",
+  async () => {
+    const now = new Date();
+    return {
+      contents: [
+        {
+          uri: "time://current",
+          mimeType: "text/plain",
+          text: `Current time: ${now.toISOString()}`,
+        },
+      ],
+    };
+  },
+  "Get the current time in ISO format",
+);
+
+// Example prompt: Generate greeting
+server.prompt(
+  "greeting",
+  "Generate a personalized greeting",
+  [
+    {
+      name: "name",
+      description: "Name of the person to greet",
+      required: true,
+    },
+    {
+      name: "style",
+      description: "Style of greeting (formal/casual)",
+      required: false,
+    },
+  ],
+  ({ name, style = "casual" }) => {
+    const greeting = style === "formal" 
+      ? `Good day, ${name}. How may I assist you today?`
+      : `Hey ${name}! What's up?`;
+    
+    return {
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: greeting,
+          },
+        },
+      ],
+    };
+  },
+);
+
+export default server;

--- a/libs/create-modelfetch/templates/node-ts/tsconfig.json.template
+++ b/libs/create-modelfetch/templates/node-ts/tsconfig.json.template
@@ -1,0 +1,20 @@
+{
+  "include": ["src"],
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "target": "es2022",
+    "lib": ["es2023"],
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "incremental": true,
+    "skipLibCheck": true,
+    "importHelpers": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "verbatimModuleSyntax": true,
+    "sourceMap": true,
+    "declarationMap": true
+  }
+}

--- a/libs/create-modelfetch/tsconfig.json
+++ b/libs/create-modelfetch/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "extends": "../../tsconfig.base.json"
+}

--- a/libs/create-modelfetch/tsconfig.lib.json
+++ b/libs/create-modelfetch/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "include": ["src"],
+  "references": [],
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "sourceRoot": "/libs/create-modelfetch/src",
+    "rootDir": "src",
+    "outDir": "dist"
+  }
+}

--- a/libs/modelfetch-bun/README.md
+++ b/libs/modelfetch-bun/README.md
@@ -112,7 +112,7 @@ bun run dist/index.js
 
 ## Documentation
 
-For complete documentation, examples, and guides, visit [modelfetch.com/docs/runtimes/bun](https://modelfetch.com/docs/runtimes/bun).
+For complete documentation, examples, and guides, visit [preview.modelfetch.com/docs/runtimes/bun](https://preview.modelfetch.com/docs/runtimes/bun).
 
 ## License
 

--- a/libs/modelfetch-bun/package.json
+++ b/libs/modelfetch-bun/package.json
@@ -24,7 +24,7 @@
     "type-fest": "^4.41.0"
   },
   "devDependencies": {
-    "@types/bun": "^1.2.17",
+    "@types/bun": "^1.2.18",
     "create-eslint-config": "workspace:^"
   }
 }

--- a/libs/modelfetch-cloudflare/README.md
+++ b/libs/modelfetch-cloudflare/README.md
@@ -1,0 +1,55 @@
+# @modelfetch/cloudflare
+
+Cloudflare Workers runtime adapter for building MCP servers with ModelFetch.
+
+## Installation
+
+```bash
+npm install @modelfetch/cloudflare
+```
+
+## Usage
+
+Create a Worker with your MCP server:
+
+```typescript
+// worker.ts
+import handle from "@modelfetch/cloudflare";
+import server from "./server";
+
+export default {
+  fetch: handle(server),
+};
+```
+
+With additional Cloudflare configurations:
+
+```typescript
+// worker.ts
+import handle from "@modelfetch/cloudflare";
+import server from "./server";
+
+export default {
+  fetch: handle(server),
+  scheduled(event, env, ctx) {
+    // Handle cron triggers
+  },
+  queue(batch, env, ctx) {
+    // Handle queue events
+  },
+};
+```
+
+## API
+
+### `handle(server)`
+
+Creates a Cloudflare Workers fetch handler from a ModelFetch server.
+
+- `server`: A ModelFetch server instance
+
+Returns a fetch function compatible with Cloudflare Workers.
+
+## License
+
+MIT

--- a/libs/modelfetch-cloudflare/eslint.config.js
+++ b/libs/modelfetch-cloudflare/eslint.config.js
@@ -1,0 +1,5 @@
+import createESLintConfig from "create-eslint-config";
+
+const eslintConfig = createESLintConfig();
+
+export default eslintConfig;

--- a/libs/modelfetch-cloudflare/package.json
+++ b/libs/modelfetch-cloudflare/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@modelfetch/cloudflare",
+  "version": "0.0.1",
+  "description": "Cloudflare Workers runtime adapter for building MCP servers with ModelFetch",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/phuctm97/modelfetch.git",
+    "directory": "libs/modelfetch-cloudflare"
+  },
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@modelfetch/core": "workspace:^",
+    "hono": "^4.8.3",
+    "type-fest": "^4.41.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20241127.0",
+    "create-eslint-config": "workspace:^"
+  }
+}

--- a/libs/modelfetch-cloudflare/package.json
+++ b/libs/modelfetch-cloudflare/package.json
@@ -21,11 +21,9 @@
   ],
   "dependencies": {
     "@modelfetch/core": "workspace:^",
-    "hono": "^4.8.3",
-    "type-fest": "^4.41.0"
+    "hono": "^4.8.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20241127.0",
     "create-eslint-config": "workspace:^"
   }
 }

--- a/libs/modelfetch-cloudflare/src/index.ts
+++ b/libs/modelfetch-cloudflare/src/index.ts
@@ -1,22 +1,8 @@
 import type { Server } from "@modelfetch/core";
-import type { Except } from "type-fest";
 
 import { createApp } from "@modelfetch/core";
 
-export type Options<
-  Env = unknown,
-  QueueHandlerMessage = unknown,
-  CfHostMetadata = unknown,
-> = Except<ExportedHandler<Env, QueueHandlerMessage, CfHostMetadata>, "fetch">;
-
-export default function handle<
-  Env = unknown,
-  QueueHandlerMessage = unknown,
-  CfHostMetadata = unknown,
->(
-  server: Server,
-  options?: Options<Env, QueueHandlerMessage, CfHostMetadata>,
-): ExportedHandler<Env, QueueHandlerMessage, CfHostMetadata> {
+export default function handle(server: Server) {
   const app = createApp(server);
-  return { ...options, fetch: app.fetch };
+  return app.fetch;
 }

--- a/libs/modelfetch-cloudflare/src/index.ts
+++ b/libs/modelfetch-cloudflare/src/index.ts
@@ -1,0 +1,22 @@
+import type { Server } from "@modelfetch/core";
+import type { Except } from "type-fest";
+
+import { createApp } from "@modelfetch/core";
+
+export type Options<
+  Env = unknown,
+  QueueHandlerMessage = unknown,
+  CfHostMetadata = unknown,
+> = Except<ExportedHandler<Env, QueueHandlerMessage, CfHostMetadata>, "fetch">;
+
+export default function handle<
+  Env = unknown,
+  QueueHandlerMessage = unknown,
+  CfHostMetadata = unknown,
+>(
+  server: Server,
+  options?: Options<Env, QueueHandlerMessage, CfHostMetadata>,
+): ExportedHandler<Env, QueueHandlerMessage, CfHostMetadata> {
+  const app = createApp(server);
+  return { ...options, fetch: app.fetch };
+}

--- a/libs/modelfetch-cloudflare/tsconfig.json
+++ b/libs/modelfetch-cloudflare/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "../modelfetch-core"
+    }
+  ],
+  "extends": "../../tsconfig.base.json"
+}

--- a/libs/modelfetch-cloudflare/tsconfig.lib.json
+++ b/libs/modelfetch-cloudflare/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../modelfetch-core/tsconfig.lib.json"
+    }
+  ],
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["@cloudflare/workers-types"],
+    "sourceRoot": "/libs/modelfetch-cloudflare/src",
+    "rootDir": "src",
+    "outDir": "dist"
+  }
+}

--- a/libs/modelfetch-cloudflare/tsconfig.lib.json
+++ b/libs/modelfetch-cloudflare/tsconfig.lib.json
@@ -7,7 +7,6 @@
   ],
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "types": ["@cloudflare/workers-types"],
     "sourceRoot": "/libs/modelfetch-cloudflare/src",
     "rootDir": "src",
     "outDir": "dist"

--- a/libs/modelfetch-core/README.md
+++ b/libs/modelfetch-core/README.md
@@ -16,7 +16,7 @@ To build MCP servers with ModelFetch, use one of the following runtime-specific 
 
 ## Documentation
 
-For complete documentation and examples, visit [modelfetch.com](https://modelfetch.com).
+For complete documentation and examples, visit [preview.modelfetch.com](https://preview.modelfetch.com).
 
 ## License
 

--- a/libs/modelfetch-deno/README.md
+++ b/libs/modelfetch-deno/README.md
@@ -137,7 +137,7 @@ Optional `deno.json`:
 
 ## Documentation
 
-For complete documentation, examples, and guides, visit [modelfetch.com/docs/runtimes/deno](https://modelfetch.com/docs/runtimes/deno).
+For complete documentation, examples, and guides, visit [preview.modelfetch.com/docs/runtimes/deno](https://preview.modelfetch.com/docs/runtimes/deno).
 
 ## License
 

--- a/libs/modelfetch-deno/README.md
+++ b/libs/modelfetch-deno/README.md
@@ -9,7 +9,7 @@ Deno runtime adapter for building MCP (Model Context Protocol) servers with Mode
 ## Installation
 
 ```bash
-deno add jsr:@modelfetch/deno
+deno add npm:@modelfetch/deno
 ```
 
 ## Quick Start
@@ -44,7 +44,7 @@ export default server;
 
 ```typescript
 // index.ts
-import handle, { getEndpoint } from "jsr:@modelfetch/deno";
+import handle, { getEndpoint } from "npm:@modelfetch/deno";
 import server from "./server.ts";
 
 // Start the server
@@ -124,7 +124,7 @@ Optional `deno.json`:
     "strict": true
   },
   "imports": {
-    "@modelfetch/deno": "jsr:@modelfetch/deno",
+    "@modelfetch/deno": "npm:@modelfetch/deno",
     "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@^0.7.0",
     "zod": "npm:zod@^3.24.1"
   },

--- a/libs/modelfetch-netlify/README.md
+++ b/libs/modelfetch-netlify/README.md
@@ -1,0 +1,62 @@
+# @modelfetch/netlify
+
+Netlify runtime adapter for building MCP servers with ModelFetch.
+
+## Installation
+
+```bash
+npm install @modelfetch/netlify
+```
+
+## Usage
+
+Create your MCP server using the official MCP TypeScript SDK:
+
+```typescript
+// server.ts
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+const server = new McpServer({
+  title: "My MCP Server",
+  name: "my-server",
+  version: "1.0.0",
+});
+
+server.tool(
+  "roll_dice",
+  "Rolls an N-sided dice",
+  { sides: z.number().int().min(2) },
+  ({ sides }) => ({
+    content: [
+      {
+        type: "text",
+        text: `🎲 You rolled a ${1 + Math.floor(Math.random() * sides)}!`,
+      },
+    ],
+  }),
+);
+
+export default server;
+```
+
+Then run it with ModelFetch's Netlify runtime:
+
+```typescript
+// netlify/functions/mcp.ts
+import handle from "@modelfetch/netlify";
+import server from "../../server";
+
+export default handle(server);
+```
+
+## Configuration
+
+The Netlify adapter automatically configures your MCP server to run as a Netlify Function. The MCP endpoint will be available at:
+
+- Development: `http://localhost:8888/api/mcp`
+- Production: `https://your-site.netlify.app/api/mcp`
+
+## Example
+
+For a complete example, check out our [Netlify example repository](https://github.com/phuctm97/modelfetch/tree/main/apps/example-netlify-ts).

--- a/libs/modelfetch-netlify/eslint.config.js
+++ b/libs/modelfetch-netlify/eslint.config.js
@@ -1,0 +1,5 @@
+import createESLintConfig from "create-eslint-config";
+
+const eslintConfig = createESLintConfig();
+
+export default eslintConfig;

--- a/libs/modelfetch-netlify/package.json
+++ b/libs/modelfetch-netlify/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@modelfetch/netlify",
+  "version": "0.0.1",
+  "description": "Netlify runtime adapter for building MCP servers with ModelFetch",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/phuctm97/modelfetch.git",
+    "directory": "libs/modelfetch-netlify"
+  },
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@modelfetch/core": "workspace:^",
+    "hono": "^4.8.3"
+  },
+  "devDependencies": {
+    "create-eslint-config": "workspace:^"
+  }
+}

--- a/libs/modelfetch-netlify/src/index.ts
+++ b/libs/modelfetch-netlify/src/index.ts
@@ -1,0 +1,9 @@
+import type { Server } from "@modelfetch/core";
+
+import { createApp } from "@modelfetch/core";
+import { handle as handler } from "hono/netlify";
+
+export default function handle(server: Server) {
+  const app = createApp(server);
+  return handler(app);
+}

--- a/libs/modelfetch-netlify/tsconfig.json
+++ b/libs/modelfetch-netlify/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "../modelfetch-core"
+    }
+  ],
+  "extends": "../../tsconfig.base.json"
+}

--- a/libs/modelfetch-netlify/tsconfig.lib.json
+++ b/libs/modelfetch-netlify/tsconfig.lib.json
@@ -1,0 +1,14 @@
+{
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../modelfetch-core/tsconfig.lib.json"
+    }
+  ],
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "sourceRoot": "/libs/modelfetch-netlify/src",
+    "rootDir": "src",
+    "outDir": "dist"
+  }
+}

--- a/libs/modelfetch-node/package.json
+++ b/libs/modelfetch-node/package.json
@@ -16,7 +16,9 @@
       "import": "./dist/index.js"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@hono/node-server": "^1.15.0",
     "@modelfetch/core": "workspace:^",

--- a/libs/modelfetch-node/package.json
+++ b/libs/modelfetch-node/package.json
@@ -1,7 +1,13 @@
 {
   "name": "@modelfetch/node",
   "version": "0.0.1",
-  "private": true,
+  "description": "Node.js runtime support for ModelFetch MCP servers",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/phuctm97/modelfetch.git",
+    "directory": "libs/modelfetch-node"
+  },
+  "license": "MIT",
   "type": "module",
   "exports": {
     ".": {
@@ -10,6 +16,7 @@
       "import": "./dist/index.js"
     }
   },
+  "files": ["dist"],
   "dependencies": {
     "@hono/node-server": "^1.15.0",
     "@modelfetch/core": "workspace:^",

--- a/libs/modelfetch-vercel/README.md
+++ b/libs/modelfetch-vercel/README.md
@@ -10,49 +10,19 @@ npm install @modelfetch/vercel
 
 ## Usage
 
-### Edge Runtime (Recommended)
-
 Create an API route in your Vercel app:
 
 ```typescript
-// app/api/mcp/route.ts (Next.js App Router)
+// app/api/mcp/route.ts
 import handle from "@modelfetch/vercel";
 import server from "./server";
 
-export const runtime = "edge";
+export const runtime = "edge"; // or "nodejs"
 
-export const GET = handle(server);
-export const POST = handle(server);
-```
-
-### Node.js Runtime
-
-```typescript
-// app/api/mcp/route.ts (Next.js App Router)
-import handle from "@modelfetch/vercel";
-import server from "./server";
-
-export const runtime = "nodejs";
-
-export const GET = handle(server);
-export const POST = handle(server);
-```
-
-### Pages Router
-
-For Next.js Pages Router:
-
-```typescript
-// pages/api/mcp.ts
-import type { PageConfig } from "next";
-import handle from "@modelfetch/vercel";
-import server from "./server";
-
-export const config: PageConfig = {
-  runtime: "edge", // or "nodejs"
-};
-
-export default handle(server);
+const handler = handle(server);
+export const GET = handler;
+export const POST = handler;
+export const DELETE = handler;
 ```
 
 ## API

--- a/libs/modelfetch-vercel/README.md
+++ b/libs/modelfetch-vercel/README.md
@@ -1,0 +1,70 @@
+# @modelfetch/vercel
+
+Vercel runtime adapter for building MCP servers with ModelFetch.
+
+## Installation
+
+```bash
+npm install @modelfetch/vercel
+```
+
+## Usage
+
+### Edge Runtime (Recommended)
+
+Create an API route in your Vercel app:
+
+```typescript
+// app/api/mcp/route.ts (Next.js App Router)
+import handle from "@modelfetch/vercel";
+import server from "./server";
+
+export const runtime = "edge";
+
+export const GET = handle(server);
+export const POST = handle(server);
+```
+
+### Node.js Runtime
+
+```typescript
+// app/api/mcp/route.ts (Next.js App Router)
+import handle from "@modelfetch/vercel";
+import server from "./server";
+
+export const runtime = "nodejs";
+
+export const GET = handle(server);
+export const POST = handle(server);
+```
+
+### Pages Router
+
+For Next.js Pages Router:
+
+```typescript
+// pages/api/mcp.ts
+import type { PageConfig } from "next";
+import handle from "@modelfetch/vercel";
+import server from "./server";
+
+export const config: PageConfig = {
+  runtime: "edge", // or "nodejs"
+};
+
+export default handle(server);
+```
+
+## API
+
+### `handle(server)`
+
+Creates a Vercel-compatible handler from a ModelFetch server.
+
+- `server`: A ModelFetch server instance
+
+Returns a handler function compatible with Vercel's runtime.
+
+## License
+
+MIT

--- a/libs/modelfetch-vercel/README.md
+++ b/libs/modelfetch-vercel/README.md
@@ -10,14 +10,12 @@ npm install @modelfetch/vercel
 
 ## Usage
 
-Create an API route in your Vercel app:
+Create an API route in your Next.js app:
 
 ```typescript
-// app/api/mcp/route.ts
+// app/mcp/route.ts
 import handle from "@modelfetch/vercel";
 import server from "./server";
-
-export const runtime = "edge"; // or "nodejs"
 
 const handler = handle(server);
 export const GET = handler;

--- a/libs/modelfetch-vercel/eslint.config.js
+++ b/libs/modelfetch-vercel/eslint.config.js
@@ -1,0 +1,5 @@
+import createESLintConfig from "create-eslint-config";
+
+const eslintConfig = createESLintConfig();
+
+export default eslintConfig;

--- a/libs/modelfetch-vercel/package.json
+++ b/libs/modelfetch-vercel/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@modelfetch/vercel",
+  "version": "0.0.1",
+  "description": "Vercel runtime adapter for building MCP servers with ModelFetch",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/phuctm97/modelfetch.git",
+    "directory": "libs/modelfetch-vercel"
+  },
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@modelfetch/core": "workspace:^",
+    "hono": "^4.8.3"
+  },
+  "devDependencies": {
+    "create-eslint-config": "workspace:^"
+  }
+}

--- a/libs/modelfetch-vercel/src/index.ts
+++ b/libs/modelfetch-vercel/src/index.ts
@@ -1,0 +1,9 @@
+import type { Server } from "@modelfetch/core";
+
+import { createApp } from "@modelfetch/core";
+import { handle as handler } from "hono/vercel";
+
+export default function handle(server: Server) {
+  const app = createApp(server);
+  return handler(app);
+}

--- a/libs/modelfetch-vercel/tsconfig.json
+++ b/libs/modelfetch-vercel/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "../modelfetch-core"
+    }
+  ],
+  "extends": "../../tsconfig.base.json"
+}

--- a/libs/modelfetch-vercel/tsconfig.lib.json
+++ b/libs/modelfetch-vercel/tsconfig.lib.json
@@ -1,0 +1,14 @@
+{
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../modelfetch-core/tsconfig.lib.json"
+    }
+  ],
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "sourceRoot": "/libs/modelfetch-vercel/src",
+    "rootDir": "src",
+    "outDir": "dist"
+  }
+}

--- a/libs/nx-10x/src/index.ts
+++ b/libs/nx-10x/src/index.ts
@@ -156,6 +156,20 @@ export const createNodesV2: CreateNodesV2 = [
             };
           }
         }
+        if (packageJson.bin) {
+          const binEntries =
+            typeof packageJson.bin === "string"
+              ? { [packageJson.name]: packageJson.bin }
+              : packageJson.bin;
+          for (const [binName, binPath] of Object.entries(binEntries)) {
+            targets[binName] = {
+              command: `node ${binPath}`,
+              options: { cwd: "{projectRoot}" },
+              continuous: true,
+              dependsOn: ["build", "^build"],
+            };
+          }
+        }
         return { projects: { [projectRoot]: { projectType, targets } } };
       },
       packageJsonFilePaths,

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "husky": "9.1.7",
     "nx": "21.2.2",
     "prettier": "3.6.2",
-    "prettier-plugin-packagejson": "2.5.17",
-    "prettier-plugin-tailwindcss": "^0.6.13",
+    "prettier-plugin-packagejson": "2.5.18",
+    "prettier-plugin-tailwindcss": "0.6.13",
     "typescript": "5.8.3"
   },
   "packageManager": "pnpm@10.12.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,13 +318,7 @@ importers:
       hono:
         specifier: ^4.8.3
         version: 4.8.3
-      type-fest:
-        specifier: ^4.41.0
-        version: 4.41.0
     devDependencies:
-      '@cloudflare/workers-types':
-        specifier: ^4.20241127.0
-        version: 4.20250704.0
       create-eslint-config:
         specifier: workspace:^
         version: link:../create-eslint-config
@@ -965,9 +959,6 @@ packages:
 
   '@clack/prompts@0.11.0':
     resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
-
-  '@cloudflare/workers-types@4.20250704.0':
-    resolution: {integrity: sha512-KR8XwXVnJdbSStdmmkkqE0ac5UCrRT+HyFnpt/VcVMzEVeAiZfH0VAcYXasMs842CE1BsdbQG0FboVV9EmyMpQ==}
 
   '@emnapi/core@1.4.3':
     resolution: {integrity: sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==}
@@ -5838,8 +5829,6 @@ snapshots:
       '@clack/core': 0.5.0
       picocolors: 1.1.1
       sisteransi: 1.0.5
-
-  '@cloudflare/workers-types@4.20250704.0': {}
 
   '@emnapi/core@1.4.3':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,6 +254,22 @@ importers:
         specifier: 8.35.1
         version: 8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
 
+  libs/create-modelfetch:
+    dependencies:
+      '@clack/prompts':
+        specifier: ^0.8.2
+        version: 0.8.2
+      ejs:
+        specifier: ^3.1.10
+        version: 3.1.10
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+    devDependencies:
+      create-eslint-config:
+        specifier: workspace:^
+        version: link:../create-eslint-config
+
   libs/eslint-config-import-paths:
     dependencies:
       eslint-plugin-no-relative-import-paths:
@@ -294,6 +310,25 @@ importers:
         specifier: workspace:^
         version: link:../create-eslint-config
 
+  libs/modelfetch-cloudflare:
+    dependencies:
+      '@modelfetch/core':
+        specifier: workspace:^
+        version: link:../modelfetch-core
+      hono:
+        specifier: ^4.8.3
+        version: 4.8.3
+      type-fest:
+        specifier: ^4.41.0
+        version: 4.41.0
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20241127.0
+        version: 4.20250704.0
+      create-eslint-config:
+        specifier: workspace:^
+        version: link:../create-eslint-config
+
   libs/modelfetch-core:
     dependencies:
       '@hono/mcp':
@@ -320,6 +355,19 @@ importers:
         specifier: workspace:^
         version: link:../create-eslint-config
 
+  libs/modelfetch-netlify:
+    dependencies:
+      '@modelfetch/core':
+        specifier: workspace:^
+        version: link:../modelfetch-core
+      hono:
+        specifier: ^4.8.3
+        version: 4.8.3
+    devDependencies:
+      create-eslint-config:
+        specifier: workspace:^
+        version: link:../create-eslint-config
+
   libs/modelfetch-node:
     dependencies:
       '@hono/node-server':
@@ -331,6 +379,19 @@ importers:
       type-fest:
         specifier: ^4.41.0
         version: 4.41.0
+    devDependencies:
+      create-eslint-config:
+        specifier: workspace:^
+        version: link:../create-eslint-config
+
+  libs/modelfetch-vercel:
+    dependencies:
+      '@modelfetch/core':
+        specifier: workspace:^
+        version: link:../modelfetch-core
+      hono:
+        specifier: ^4.8.3
+        version: 4.8.3
     devDependencies:
       create-eslint-config:
         specifier: workspace:^
@@ -898,6 +959,15 @@ packages:
   '@babel/types@7.28.0':
     resolution: {integrity: sha512-jYnje+JyZG5YThjHiF28oT4SIZLnYOcSBb6+SDaFIyzDVSkXQmQQYclJ2R+YxcdmK0AX6x1E5OQNtuh3jHDrUg==}
     engines: {node: '>=6.9.0'}
+
+  '@clack/core@0.3.5':
+    resolution: {integrity: sha512-5cfhQNH+1VQ2xLQlmzXMqUoiaH0lRBq9/CLW9lTyMbuKLC3+xEK01tHVvyut++mLOn5urSHmkm6I0Lg9MaJSTQ==}
+
+  '@clack/prompts@0.8.2':
+    resolution: {integrity: sha512-6b9Ab2UiZwJYA9iMyboYyW9yJvAO9V753ZhS+DHKEjZRKAxPPOb7MXXu84lsPFG+vZt6FRFniZ8rXi+zCIw4yQ==}
+
+  '@cloudflare/workers-types@4.20250704.0':
+    resolution: {integrity: sha512-KR8XwXVnJdbSStdmmkkqE0ac5UCrRT+HyFnpt/VcVMzEVeAiZfH0VAcYXasMs842CE1BsdbQG0FboVV9EmyMpQ==}
 
   '@emnapi/core@1.4.3':
     resolution: {integrity: sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==}
@@ -4607,6 +4677,9 @@ packages:
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   sort-object-keys@1.1.3:
     resolution: {integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==}
 
@@ -5746,6 +5819,19 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
+
+  '@clack/core@0.3.5':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.8.2':
+    dependencies:
+      '@clack/core': 0.3.5
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@cloudflare/workers-types@4.20250704.0': {}
 
   '@emnapi/core@1.4.3':
     dependencies:
@@ -9971,6 +10057,8 @@ snapshots:
     dependencies:
       is-arrayish: 0.3.2
     optional: true
+
+  sisteransi@1.0.5: {}
 
   sort-object-keys@1.1.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,7 +265,13 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+      validate-npm-package-name:
+        specifier: ^6.0.0
+        version: 6.0.1
     devDependencies:
+      '@types/validate-npm-package-name':
+        specifier: ^4.0.2
+        version: 4.0.2
       create-eslint-config:
         specifier: workspace:^
         version: link:../create-eslint-config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,10 +40,10 @@ importers:
         specifier: 3.6.2
         version: 3.6.2
       prettier-plugin-packagejson:
-        specifier: 2.5.17
-        version: 2.5.17(prettier@3.6.2)
+        specifier: 2.5.18
+        version: 2.5.18(prettier@3.6.2)
       prettier-plugin-tailwindcss:
-        specifier: ^0.6.13
+        specifier: 0.6.13
         version: 0.6.13(prettier@3.6.2)
       typescript:
         specifier: 5.8.3
@@ -58,8 +58,8 @@ importers:
         specifier: workspace:^
         version: link:../../libs/modelfetch-bun
       zod:
-        specifier: ^3.25.67
-        version: 3.25.71
+        specifier: ^3.25.72
+        version: 3.25.72
     devDependencies:
       modelfetch:
         specifier: workspace:^
@@ -74,12 +74,12 @@ importers:
         specifier: workspace:^
         version: link:../../libs/modelfetch-bun
       zod:
-        specifier: ^3.25.67
-        version: 3.25.71
+        specifier: ^3.25.72
+        version: 3.25.72
     devDependencies:
       '@types/bun':
-        specifier: ^1.2.17
-        version: 1.2.17
+        specifier: ^1.2.18
+        version: 1.2.18(@types/react@19.1.8)
       create-eslint-config:
         specifier: workspace:^
         version: link:../../libs/create-eslint-config
@@ -96,8 +96,8 @@ importers:
         specifier: workspace:^
         version: link:../../libs/modelfetch-deno
       zod:
-        specifier: ^3.25.67
-        version: 3.25.71
+        specifier: ^3.25.72
+        version: 3.25.72
     devDependencies:
       modelfetch:
         specifier: workspace:^
@@ -112,8 +112,8 @@ importers:
         specifier: workspace:^
         version: link:../../libs/modelfetch-deno
       zod:
-        specifier: ^3.25.67
-        version: 3.25.71
+        specifier: ^3.25.72
+        version: 3.25.72
     devDependencies:
       '@types/deno':
         specifier: ^2.3.0
@@ -134,8 +134,8 @@ importers:
         specifier: workspace:^
         version: link:../../libs/modelfetch-node
       zod:
-        specifier: ^3.25.67
-        version: 3.25.71
+        specifier: ^3.25.72
+        version: 3.25.72
     devDependencies:
       modelfetch:
         specifier: workspace:^
@@ -150,8 +150,8 @@ importers:
         specifier: workspace:^
         version: link:../../libs/modelfetch-node
       zod:
-        specifier: ^3.25.67
-        version: 3.25.71
+        specifier: ^3.25.72
+        version: 3.25.72
     devDependencies:
       create-eslint-config:
         specifier: workspace:^
@@ -170,19 +170,19 @@ importers:
         version: 8.1.2(react@19.1.0)
       fumadocs-core:
         specifier: ^15.6.1
-        version: 15.6.1(@types/react@19.1.8)(next@15.3.4(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.6.1(@types/react@19.1.8)(next@15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       fumadocs-mdx:
         specifier: ^11.6.10
-        version: 11.6.10(acorn@8.15.0)(fumadocs-core@15.6.1(@types/react@19.1.8)(next@15.3.4(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(next@15.3.4(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+        version: 11.6.10(acorn@8.15.0)(fumadocs-core@15.6.1(@types/react@19.1.8)(next@15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(next@15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       fumadocs-ui:
         specifier: ^15.6.1
-        version: 15.6.1(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(next@15.3.4(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.11)
+        version: 15.6.1(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(next@15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.11)
       lucide-react:
         specifier: ^0.525.0
         version: 0.525.0(react@19.1.0)
       next:
-        specifier: ^15.3.4
-        version: 15.3.4(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^15.3.5
+        version: 15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -193,12 +193,12 @@ importers:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
       zod:
-        specifier: ^3.25.67
-        version: 3.25.71
+        specifier: ^3.25.72
+        version: 3.25.72
     devDependencies:
       '@next/eslint-plugin-next':
-        specifier: ^15.3.4
-        version: 15.3.4
+        specifier: ^15.3.5
+        version: 15.3.5
       '@tailwindcss/postcss':
         specifier: ^4.1.11
         version: 4.1.11
@@ -257,8 +257,8 @@ importers:
   libs/create-modelfetch:
     dependencies:
       '@clack/prompts':
-        specifier: ^0.8.2
-        version: 0.8.2
+        specifier: ^0.11.0
+        version: 0.11.0
       ejs:
         specifier: ^3.1.10
         version: 3.1.10
@@ -304,8 +304,8 @@ importers:
         version: 4.41.0
     devDependencies:
       '@types/bun':
-        specifier: ^1.2.17
-        version: 1.2.17
+        specifier: ^1.2.18
+        version: 1.2.18(@types/react@19.1.8)
       create-eslint-config:
         specifier: workspace:^
         version: link:../create-eslint-config
@@ -960,11 +960,11 @@ packages:
     resolution: {integrity: sha512-jYnje+JyZG5YThjHiF28oT4SIZLnYOcSBb6+SDaFIyzDVSkXQmQQYclJ2R+YxcdmK0AX6x1E5OQNtuh3jHDrUg==}
     engines: {node: '>=6.9.0'}
 
-  '@clack/core@0.3.5':
-    resolution: {integrity: sha512-5cfhQNH+1VQ2xLQlmzXMqUoiaH0lRBq9/CLW9lTyMbuKLC3+xEK01tHVvyut++mLOn5urSHmkm6I0Lg9MaJSTQ==}
+  '@clack/core@0.5.0':
+    resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
 
-  '@clack/prompts@0.8.2':
-    resolution: {integrity: sha512-6b9Ab2UiZwJYA9iMyboYyW9yJvAO9V753ZhS+DHKEjZRKAxPPOb7MXXu84lsPFG+vZt6FRFniZ8rXi+zCIw4yQ==}
+  '@clack/prompts@0.11.0':
+    resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
 
   '@cloudflare/workers-types@4.20250704.0':
     resolution: {integrity: sha512-KR8XwXVnJdbSStdmmkkqE0ac5UCrRT+HyFnpt/VcVMzEVeAiZfH0VAcYXasMs842CE1BsdbQG0FboVV9EmyMpQ==}
@@ -1383,56 +1383,56 @@ packages:
   '@napi-rs/wasm-runtime@0.2.4':
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
 
-  '@next/env@15.3.4':
-    resolution: {integrity: sha512-ZkdYzBseS6UjYzz6ylVKPOK+//zLWvD6Ta+vpoye8cW11AjiQjGYVibF0xuvT4L0iJfAPfZLFidaEzAOywyOAQ==}
+  '@next/env@15.3.5':
+    resolution: {integrity: sha512-7g06v8BUVtN2njAX/r8gheoVffhiKFVt4nx74Tt6G4Hqw9HCLYQVx/GkH2qHvPtAHZaUNZ0VXAa0pQP6v1wk7g==}
 
-  '@next/eslint-plugin-next@15.3.4':
-    resolution: {integrity: sha512-lBxYdj7TI8phbJcLSAqDt57nIcobEign5NYIKCiy0hXQhrUbTqLqOaSDi568U6vFg4hJfBdZYsG4iP/uKhCqgg==}
+  '@next/eslint-plugin-next@15.3.5':
+    resolution: {integrity: sha512-BZwWPGfp9po/rAnJcwUBaM+yT/+yTWIkWdyDwc74G9jcfTrNrmsHe+hXHljV066YNdVs8cxROxX5IgMQGX190w==}
 
-  '@next/swc-darwin-arm64@15.3.4':
-    resolution: {integrity: sha512-z0qIYTONmPRbwHWvpyrFXJd5F9YWLCsw3Sjrzj2ZvMYy9NPQMPZ1NjOJh4ojr4oQzcGYwgJKfidzehaNa1BpEg==}
+  '@next/swc-darwin-arm64@15.3.5':
+    resolution: {integrity: sha512-lM/8tilIsqBq+2nq9kbTW19vfwFve0NR7MxfkuSUbRSgXlMQoJYg+31+++XwKVSXk4uT23G2eF/7BRIKdn8t8w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.3.4':
-    resolution: {integrity: sha512-Z0FYJM8lritw5Wq+vpHYuCIzIlEMjewG2aRkc3Hi2rcbULknYL/xqfpBL23jQnCSrDUGAo/AEv0Z+s2bff9Zkw==}
+  '@next/swc-darwin-x64@15.3.5':
+    resolution: {integrity: sha512-WhwegPQJ5IfoUNZUVsI9TRAlKpjGVK0tpJTL6KeiC4cux9774NYE9Wu/iCfIkL/5J8rPAkqZpG7n+EfiAfidXA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.3.4':
-    resolution: {integrity: sha512-l8ZQOCCg7adwmsnFm8m5q9eIPAHdaB2F3cxhufYtVo84pymwKuWfpYTKcUiFcutJdp9xGHC+F1Uq3xnFU1B/7g==}
+  '@next/swc-linux-arm64-gnu@15.3.5':
+    resolution: {integrity: sha512-LVD6uMOZ7XePg3KWYdGuzuvVboxujGjbcuP2jsPAN3MnLdLoZUXKRc6ixxfs03RH7qBdEHCZjyLP/jBdCJVRJQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.3.4':
-    resolution: {integrity: sha512-wFyZ7X470YJQtpKot4xCY3gpdn8lE9nTlldG07/kJYexCUpX1piX+MBfZdvulo+t1yADFVEuzFfVHfklfEx8kw==}
+  '@next/swc-linux-arm64-musl@15.3.5':
+    resolution: {integrity: sha512-k8aVScYZ++BnS2P69ClK7v4nOu702jcF9AIHKu6llhHEtBSmM2zkPGl9yoqbSU/657IIIb0QHpdxEr0iW9z53A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.3.4':
-    resolution: {integrity: sha512-gEbH9rv9o7I12qPyvZNVTyP/PWKqOp8clvnoYZQiX800KkqsaJZuOXkWgMa7ANCCh/oEN2ZQheh3yH8/kWPSEg==}
+  '@next/swc-linux-x64-gnu@15.3.5':
+    resolution: {integrity: sha512-2xYU0DI9DGN/bAHzVwADid22ba5d/xrbrQlr2U+/Q5WkFUzeL0TDR963BdrtLS/4bMmKZGptLeg6282H/S2i8A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.3.4':
-    resolution: {integrity: sha512-Cf8sr0ufuC/nu/yQ76AnarbSAXcwG/wj+1xFPNbyNo8ltA6kw5d5YqO8kQuwVIxk13SBdtgXrNyom3ZosHAy4A==}
+  '@next/swc-linux-x64-musl@15.3.5':
+    resolution: {integrity: sha512-TRYIqAGf1KCbuAB0gjhdn5Ytd8fV+wJSM2Nh2is/xEqR8PZHxfQuaiNhoF50XfY90sNpaRMaGhF6E+qjV1b9Tg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@15.3.4':
-    resolution: {integrity: sha512-ay5+qADDN3rwRbRpEhTOreOn1OyJIXS60tg9WMYTWCy3fB6rGoyjLVxc4dR9PYjEdR2iDYsaF5h03NA+XuYPQQ==}
+  '@next/swc-win32-arm64-msvc@15.3.5':
+    resolution: {integrity: sha512-h04/7iMEUSMY6fDGCvdanKqlO1qYvzNxntZlCzfE8i5P0uqzVQWQquU1TIhlz0VqGQGXLrFDuTJVONpqGqjGKQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.3.4':
-    resolution: {integrity: sha512-4kDt31Bc9DGyYs41FTL1/kNpDeHyha2TC0j5sRRoKCyrhNcfZ/nRQkAUlF27mETwm8QyHqIjHJitfcza2Iykfg==}
+  '@next/swc-win32-x64-msvc@15.3.5':
+    resolution: {integrity: sha512-5fhH6fccXxnX2KhllnGhkYMndhOiLOLEiVGYjP2nizqeGWkN10sA9taATlXwake2E2XMvYZjjz0Uj7T0y+z1yw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2168,8 +2168,8 @@ packages:
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
 
-  '@types/bun@1.2.17':
-    resolution: {integrity: sha512-l/BYs/JYt+cXA/0+wUhulYJB6a6p//GTPiJ7nV+QHa8iiId4HZmnu/3J/SowP5g0rTiERY2kfGKXEK5Ehltx4Q==}
+  '@types/bun@1.2.18':
+    resolution: {integrity: sha512-Xf6RaWVheyemaThV0kUfaAUvCNokFr+bH8Jxp+tTZfx7dAPA8z9ePnP9S9+Vspzuxxx9JRAXhnyccRj3GyCMdQ==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -2203,6 +2203,9 @@ packages:
 
   '@types/node@22.15.34':
     resolution: {integrity: sha512-8Y6E5WUupYy1Dd0II32BsWAx5MWdcnRd8L84Oys3veg1YrYtNtzgO4CFhiBg6MDSjk7Ay36HYOnU7/tuOzIzcw==}
+
+  '@types/node@24.0.10':
+    resolution: {integrity: sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -2581,8 +2584,10 @@ packages:
     resolution: {integrity: sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==}
     engines: {node: '>=18.20'}
 
-  bun-types@1.2.17:
-    resolution: {integrity: sha512-ElC7ItwT3SCQwYZDYoAH+q6KT4Fxjl8DtZ6qDulUFBmXA8YB4xo+l54J9ZJN+k2pphfn9vk7kfubeSd5QfTVJQ==}
+  bun-types@1.2.18:
+    resolution: {integrity: sha512-04+Eha5NP7Z0A9YgDAzMk5PHR16ZuLVa83b26kH5+cp1qZW4F6FmAURngE7INf4tKOvCE69vYvDEwoNl1tGiWw==}
+    peerDependencies:
+      '@types/react': ^19
 
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -4102,8 +4107,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@15.3.4:
-    resolution: {integrity: sha512-mHKd50C+mCjam/gcnwqL1T1vPx/XQNFlXqFIVdgQdVAFY9iIQtY0IfaVflEYzKiqjeA7B0cYYMaCrmAYFjs4rA==}
+  next@15.3.5:
+    resolution: {integrity: sha512-RkazLBMMDJSJ4XZQ81kolSpwiCt907l0xcgcpF4xC2Vml6QVcPNXW0NQRwQ80FFtSn7UM52XN0anaw8TEJXaiw==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -4306,8 +4311,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier-plugin-packagejson@2.5.17:
-    resolution: {integrity: sha512-1WYvhTix+4EMYZQYSjAxb6+KTCULINuHUTBcxYa2ipoUS9Y2zJVjE3kuZ5I7ZWIFqyK8xpwYIunXqN5eiT7Hew==}
+  prettier-plugin-packagejson@2.5.18:
+    resolution: {integrity: sha512-NKznPGcGrcj4NPGxnh+w78JXPyfB6I4RQSCM0v+CAXwpDG7OEpJQ5zMyfC5NBgKH1k7Skwcj5ak5by2mrHvC5g==}
     peerDependencies:
       prettier: '>= 1.16.0'
     peerDependenciesMeta:
@@ -4683,8 +4688,8 @@ packages:
   sort-object-keys@1.1.3:
     resolution: {integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==}
 
-  sort-package-json@3.3.1:
-    resolution: {integrity: sha512-awjhQR2Iy5UN3NuguAK5+RezcEuUg9Ra4O8y2Aj+DlJa7MywyHaipAPf9bu4qqFj0hsYHHoT9sS3aV7Ucu728g==}
+  sort-package-json@3.4.0:
+    resolution: {integrity: sha512-97oFRRMM2/Js4oEA9LJhjyMlde+2ewpZQf53pgue27UkbEXfHJnDzHlUxQ/DWUkzqmp7DFwJp8D+wi/TYeQhpA==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -4927,6 +4932,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.8.0:
+    resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
+
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -5093,8 +5101,8 @@ packages:
     peerDependencies:
       zod: ^3.24.1
 
-  zod@3.25.71:
-    resolution: {integrity: sha512-BsBc/NPk7h8WsUWYWYL+BajcJPY8YhjelaWu2NMLuzgraKAz4Lb4/6K11g9jpuDetjMiqhZ6YaexFLOC0Ogi3Q==}
+  zod@3.25.72:
+    resolution: {integrity: sha512-Cl+fe4dNL4XumOBNBsr0lHfA80PQiZXHI4xEMTEr8gt6aGz92t3lBA32e71j9+JeF/VAYvdfBnuwJs+BMx/BrA==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -5820,14 +5828,14 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
-  '@clack/core@0.3.5':
+  '@clack/core@0.5.0':
     dependencies:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  '@clack/prompts@0.8.2':
+  '@clack/prompts@0.11.0':
     dependencies:
-      '@clack/core': 0.3.5
+      '@clack/core': 0.5.0
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
@@ -6170,8 +6178,8 @@ snapshots:
       express-rate-limit: 7.5.1(express@5.1.0)
       pkce-challenge: 5.0.0
       raw-body: 3.0.0
-      zod: 3.25.71
-      zod-to-json-schema: 3.24.6(zod@3.25.71)
+      zod: 3.25.72
+      zod-to-json-schema: 3.24.6(zod@3.25.72)
     transitivePeerDependencies:
       - supports-color
 
@@ -6188,34 +6196,34 @@ snapshots:
       '@emnapi/runtime': 1.4.3
       '@tybys/wasm-util': 0.9.0
 
-  '@next/env@15.3.4': {}
+  '@next/env@15.3.5': {}
 
-  '@next/eslint-plugin-next@15.3.4':
+  '@next/eslint-plugin-next@15.3.5':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.3.4':
+  '@next/swc-darwin-arm64@15.3.5':
     optional: true
 
-  '@next/swc-darwin-x64@15.3.4':
+  '@next/swc-darwin-x64@15.3.5':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.3.4':
+  '@next/swc-linux-arm64-gnu@15.3.5':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.3.4':
+  '@next/swc-linux-arm64-musl@15.3.5':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.3.4':
+  '@next/swc-linux-x64-gnu@15.3.5':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.3.4':
+  '@next/swc-linux-x64-musl@15.3.5':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.3.4':
+  '@next/swc-win32-arm64-msvc@15.3.5':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.3.4':
+  '@next/swc-win32-x64-msvc@15.3.5':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -6935,9 +6943,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@types/bun@1.2.17':
+  '@types/bun@1.2.18(@types/react@19.1.8)':
     dependencies:
-      bun-types: 1.2.17
+      bun-types: 1.2.18(@types/react@19.1.8)
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@types/debug@4.1.12':
     dependencies:
@@ -6970,6 +6980,10 @@ snapshots:
   '@types/node@22.15.34':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/node@24.0.10':
+    dependencies:
+      undici-types: 7.8.0
 
   '@types/parse-json@4.0.2': {}
 
@@ -7387,9 +7401,10 @@ snapshots:
 
   builtin-modules@5.0.0: {}
 
-  bun-types@1.2.17:
+  bun-types@1.2.18(@types/react@19.1.8):
     dependencies:
-      '@types/node': 22.15.34
+      '@types/node': 24.0.10
+      '@types/react': 19.1.8
 
   busboy@1.6.0:
     dependencies:
@@ -8224,7 +8239,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@15.6.1(@types/react@19.1.8)(next@15.3.4(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  fumadocs-core@15.6.1(@types/react@19.1.8)(next@15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@formatjs/intl-localematcher': 0.6.1
       '@orama/orama': 3.1.10
@@ -8245,34 +8260,34 @@ snapshots:
       unist-util-visit: 5.0.0
     optionalDependencies:
       '@types/react': 19.1.8
-      next: 15.3.4(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@11.6.10(acorn@8.15.0)(fumadocs-core@15.6.1(@types/react@19.1.8)(next@15.3.4(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(next@15.3.4(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)):
+  fumadocs-mdx@11.6.10(acorn@8.15.0)(fumadocs-core@15.6.1(@types/react@19.1.8)(next@15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(next@15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.0(acorn@8.15.0)
       '@standard-schema/spec': 1.0.0
       chokidar: 4.0.3
       esbuild: 0.25.5
       estree-util-value-to-estree: 3.4.0
-      fumadocs-core: 15.6.1(@types/react@19.1.8)(next@15.3.4(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      fumadocs-core: 15.6.1(@types/react@19.1.8)(next@15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       js-yaml: 4.1.0
       lru-cache: 11.1.0
       picocolors: 1.1.1
       tinyexec: 1.0.1
       tinyglobby: 0.2.14
       unist-util-visit: 5.0.0
-      zod: 3.25.71
+      zod: 3.25.72
     optionalDependencies:
-      next: 15.3.4(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - acorn
       - supports-color
 
-  fumadocs-ui@15.6.1(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(next@15.3.4(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.11):
+  fumadocs-ui@15.6.1(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(next@15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.11):
     dependencies:
       '@radix-ui/react-accordion': 1.2.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-collapsible': 1.1.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -8285,7 +8300,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.1.8)(react@19.1.0)
       '@radix-ui/react-tabs': 1.1.12(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       class-variance-authority: 0.7.1
-      fumadocs-core: 15.6.1(@types/react@19.1.8)(next@15.3.4(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      fumadocs-core: 15.6.1(@types/react@19.1.8)(next@15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       lodash.merge: 4.6.2
       next-themes: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       postcss-selector-parser: 7.1.0
@@ -8296,7 +8311,7 @@ snapshots:
       tailwind-merge: 3.3.1
     optionalDependencies:
       '@types/react': 19.1.8
-      next: 15.3.4(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       tailwindcss: 4.1.11
     transitivePeerDependencies:
       - '@oramacloud/client'
@@ -9330,9 +9345,9 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  next@15.3.4(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      '@next/env': 15.3.4
+      '@next/env': 15.3.5
       '@swc/counter': 0.1.3
       '@swc/helpers': 0.5.15
       busboy: 1.6.0
@@ -9342,14 +9357,14 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       styled-jsx: 5.1.6(@babel/core@7.28.0)(react@19.1.0)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.3.4
-      '@next/swc-darwin-x64': 15.3.4
-      '@next/swc-linux-arm64-gnu': 15.3.4
-      '@next/swc-linux-arm64-musl': 15.3.4
-      '@next/swc-linux-x64-gnu': 15.3.4
-      '@next/swc-linux-x64-musl': 15.3.4
-      '@next/swc-win32-arm64-msvc': 15.3.4
-      '@next/swc-win32-x64-msvc': 15.3.4
+      '@next/swc-darwin-arm64': 15.3.5
+      '@next/swc-darwin-x64': 15.3.5
+      '@next/swc-linux-arm64-gnu': 15.3.5
+      '@next/swc-linux-arm64-musl': 15.3.5
+      '@next/swc-linux-x64-gnu': 15.3.5
+      '@next/swc-linux-x64-musl': 15.3.5
+      '@next/swc-win32-arm64-msvc': 15.3.5
+      '@next/swc-win32-x64-msvc': 15.3.5
       sharp: 0.34.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -9609,9 +9624,9 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-packagejson@2.5.17(prettier@3.6.2):
+  prettier-plugin-packagejson@2.5.18(prettier@3.6.2):
     dependencies:
-      sort-package-json: 3.3.1
+      sort-package-json: 3.4.0
       synckit: 0.11.8
     optionalDependencies:
       prettier: 3.6.2
@@ -10062,7 +10077,7 @@ snapshots:
 
   sort-object-keys@1.1.3: {}
 
-  sort-package-json@3.3.1:
+  sort-package-json@3.4.0:
     dependencies:
       detect-indent: 7.0.1
       detect-newline: 4.0.1
@@ -10343,6 +10358,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici-types@7.8.0: {}
+
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -10543,10 +10560,10 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-to-json-schema@3.24.6(zod@3.25.71):
+  zod-to-json-schema@3.24.6(zod@3.25.72):
     dependencies:
-      zod: 3.25.71
+      zod: 3.25.72
 
-  zod@3.25.71: {}
+  zod@3.25.72: {}
 
   zwitch@2.0.4: {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,10 +14,16 @@
       "path": "./apps/modelfetch-website"
     },
     {
+      "path": "./libs/create-modelfetch"
+    },
+    {
       "path": "./libs/modelfetch"
     },
     {
       "path": "./libs/modelfetch-bun"
+    },
+    {
+      "path": "./libs/modelfetch-cloudflare"
     },
     {
       "path": "./libs/modelfetch-core"
@@ -26,7 +32,13 @@
       "path": "./libs/modelfetch-deno"
     },
     {
+      "path": "./libs/modelfetch-netlify"
+    },
+    {
       "path": "./libs/modelfetch-node"
+    },
+    {
+      "path": "./libs/modelfetch-vercel"
     },
     {
       "path": "./libs/nx-10x"


### PR DESCRIPTION
## Summary
- Added `create-modelfetch` CLI package for scaffolding new MCP server projects with support for Node.js and TypeScript templates
- Implemented runtime adapters for Cloudflare Workers, Vercel Functions, and Netlify Functions
- Updated documentation to include new runtime packages and deployment guides

## Test plan
- [ ] Test `create-modelfetch` CLI with both Node.js and TypeScript templates
- [ ] Verify Cloudflare adapter exports correct types and handles all Worker lifecycle events
- [ ] Test Vercel adapter exports both GET and POST handlers
- [ ] Verify Netlify adapter exports compatible handler function
- [ ] Check that all packages have proper TypeScript configurations and ESLint setups
- [ ] Ensure documentation accurately reflects new packages and deployment options
- [ ] Validate that package.json files follow workspace conventions (no duplicate dependencies)

🤖 Generated with [Claude Code](https://claude.ai/code)