### PR TITLE
Enhance create-modelfetch CLI with improved UX and branding

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,7 +24,7 @@ jobs:
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org
       - run: pnpm i
-      - run: pnpm exec nx run-many -t typecheck lint build -p tag:npm:public
+      - run: pnpm exec nx run-many -t typecheck lint build
       - run: pnpm exec nx release publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,6 @@ jobs:
           cache: pnpm
           node-version-file: .nvmrc
       - run: pnpm i
-      - run: pnpm exec nx run-many -t typecheck lint build -p tag:npm:public
+      - run: pnpm exec nx run-many -t typecheck lint build
       - run: pnpm exec nx release --skip-publish
       - run: git push --follow-tags

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,9 @@
 {
   "mcpServers": {
     "nx-mcp": {
-      "type": "http",
-      "url": "http://localhost:9685/mcp"
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "nx-mcp@latest", "."]
     }
   }
 }

--- a/.nx/version-plans/enhance-create-modelfetch-cli-ux.md
+++ b/.nx/version-plans/enhance-create-modelfetch-cli-ux.md
@@ -1,0 +1,5 @@
+---
+__default__: minor
+---
+
+Enhance create-modelfetch CLI with ASCII art logo, improved prompts, and better error handling

--- a/libs/create-modelfetch/package.json
+++ b/libs/create-modelfetch/package.json
@@ -25,6 +25,7 @@
   ],
   "dependencies": {
     "@clack/prompts": "^0.11.0",
+    "change-case": "^5.4.4",
     "ejs": "^3.1.10",
     "picocolors": "^1.1.1",
     "validate-npm-package-name": "^6.0.0"

--- a/nx.json
+++ b/nx.json
@@ -26,6 +26,7 @@
   },
   "release": {
     "versionPlans": true,
+    "projects": ["*"],
     "git": { "commitMessage": "Release v{version}" }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,6 +259,9 @@ importers:
       '@clack/prompts':
         specifier: ^0.11.0
         version: 0.11.0
+      change-case:
+        specifier: ^5.4.4
+        version: 5.4.4
       ejs:
         specifier: ^3.1.10
         version: 3.1.10
@@ -2625,6 +2628,9 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  change-case@5.4.4:
+    resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -7442,6 +7448,8 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  change-case@5.4.4: {}
 
   character-entities-html4@2.1.0: {}
 


### PR DESCRIPTION
## Summary
- Added ASCII art logo and hero title for better branding
- Improved user prompts with clearer naming ("MCP server" instead of "project")
- Enhanced error handling with proper fallback values for empty inputs
- Added change-case dependency for automatic title generation
- Fixed nx release configuration to build all projects
- Updated MCP configuration to use stdio instead of http

## Test plan
- [x] Run `pnpm exec nx build create-modelfetch` to build the CLI
- [x] Test the CLI with various inputs including empty values
- [x] Verify ASCII art displays correctly
- [x] Check that generated project names and titles are properly formatted
- [x] Ensure all runtime templates still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)