### PR TITLE
Update documentation URLs to www.modelfetch.com

### DIFF
--- a/.nx/version-plans/update-website-url-to-www.md
+++ b/.nx/version-plans/update-website-url-to-www.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Update all documentation URLs from preview.modelfetch.com to www.modelfetch.com

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ pnpm -w format
 
 - [Model Context Protocol - TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
 - [Model Context Protocol - Documentation](https://modelcontextprotocol.io)
-- [ModelFetch - Website](https://preview.modelfetch.com)
-- [ModelFetch - Documentation](https://preview.modelfetch.com/docs)
+- [ModelFetch - Website](https://www.modelfetch.com)
+- [ModelFetch - Documentation](https://www.modelfetch.com/docs)
 
 ## 📄 License
 

--- a/libs/create-modelfetch/src/index.ts
+++ b/libs/create-modelfetch/src/index.ts
@@ -337,7 +337,7 @@ async function main() {
     console.log(`  ${pc.cyan("npx @modelcontextprotocol/inspector")}`);
     console.log();
     console.log(pc.gray("  Read the documentation:"));
-    console.log(`  ${pc.cyan("https://preview.modelfetch.com/docs")}`);
+    console.log(`  ${pc.cyan("https://www.modelfetch.com/docs")}`);
     console.log();
   } catch (error) {
     s.stop("create-modelfetch CLI failed!");

--- a/libs/create-modelfetch/templates/bun-js/README.md.template
+++ b/libs/create-modelfetch/templates/bun-js/README.md.template
@@ -1,6 +1,6 @@
 # <%= projectTitle %>
 
-An MCP server built with [ModelFetch](https://preview.modelfetch.com)
+An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ## Quick Start
 
@@ -112,6 +112,6 @@ server.registerPrompt(
 
 - [Model Context Protocol - Documentation](https://modelcontextprotocol.io)
 - [Model Context Protocol - TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
-- [ModelFetch - Website](https://preview.modelfetch.com)
-- [ModelFetch - Documentation](https://preview.modelfetch.com/docs)
+- [ModelFetch - Website](https://www.modelfetch.com)
+- [ModelFetch - Documentation](https://www.modelfetch.com/docs)
 - [ModelFetch - GitHub](https://github.com/phuctm97/modelfetch)

--- a/libs/create-modelfetch/templates/bun-ts/README.md.template
+++ b/libs/create-modelfetch/templates/bun-ts/README.md.template
@@ -1,6 +1,6 @@
 # <%= projectTitle %>
 
-An MCP server built with [ModelFetch](https://preview.modelfetch.com)
+An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ## Quick Start
 
@@ -112,6 +112,6 @@ server.registerPrompt(
 
 - [Model Context Protocol - Documentation](https://modelcontextprotocol.io)
 - [Model Context Protocol - TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
-- [ModelFetch - Website](https://preview.modelfetch.com)
-- [ModelFetch - Documentation](https://preview.modelfetch.com/docs)
+- [ModelFetch - Website](https://www.modelfetch.com)
+- [ModelFetch - Documentation](https://www.modelfetch.com/docs)
 - [ModelFetch - GitHub](https://github.com/phuctm97/modelfetch)

--- a/libs/create-modelfetch/templates/deno-js/README.md.template
+++ b/libs/create-modelfetch/templates/deno-js/README.md.template
@@ -1,6 +1,6 @@
 # <%= projectTitle %>
 
-An MCP server built with [ModelFetch](https://preview.modelfetch.com)
+An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ## Quick Start
 
@@ -112,6 +112,6 @@ server.registerPrompt(
 
 - [Model Context Protocol - Documentation](https://modelcontextprotocol.io)
 - [Model Context Protocol - TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
-- [ModelFetch - Website](https://preview.modelfetch.com)
-- [ModelFetch - Documentation](https://preview.modelfetch.com/docs)
+- [ModelFetch - Website](https://www.modelfetch.com)
+- [ModelFetch - Documentation](https://www.modelfetch.com/docs)
 - [ModelFetch - GitHub](https://github.com/phuctm97/modelfetch)

--- a/libs/create-modelfetch/templates/deno-ts/README.md.template
+++ b/libs/create-modelfetch/templates/deno-ts/README.md.template
@@ -1,6 +1,6 @@
 # <%= projectTitle %>
 
-An MCP server built with [ModelFetch](https://preview.modelfetch.com)
+An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ## Quick Start
 
@@ -112,6 +112,6 @@ server.registerPrompt(
 
 - [Model Context Protocol - Documentation](https://modelcontextprotocol.io)
 - [Model Context Protocol - TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
-- [ModelFetch - Website](https://preview.modelfetch.com)
-- [ModelFetch - Documentation](https://preview.modelfetch.com/docs)
+- [ModelFetch - Website](https://www.modelfetch.com)
+- [ModelFetch - Documentation](https://www.modelfetch.com/docs)
 - [ModelFetch - GitHub](https://github.com/phuctm97/modelfetch)

--- a/libs/create-modelfetch/templates/node-js/README.md.template
+++ b/libs/create-modelfetch/templates/node-js/README.md.template
@@ -1,6 +1,6 @@
 # <%= projectTitle %>
 
-An MCP server built with [ModelFetch](https://preview.modelfetch.com)
+An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ## Quick Start
 
@@ -112,6 +112,6 @@ server.registerPrompt(
 
 - [Model Context Protocol - Documentation](https://modelcontextprotocol.io)
 - [Model Context Protocol - TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
-- [ModelFetch - Website](https://preview.modelfetch.com)
-- [ModelFetch - Documentation](https://preview.modelfetch.com/docs)
+- [ModelFetch - Website](https://www.modelfetch.com)
+- [ModelFetch - Documentation](https://www.modelfetch.com/docs)
 - [ModelFetch - GitHub](https://github.com/phuctm97/modelfetch)

--- a/libs/create-modelfetch/templates/node-ts/README.md.template
+++ b/libs/create-modelfetch/templates/node-ts/README.md.template
@@ -1,6 +1,6 @@
 # <%= projectTitle %>
 
-An MCP server built with [ModelFetch](https://preview.modelfetch.com)
+An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ## Quick Start
 
@@ -113,6 +113,6 @@ server.registerPrompt(
 
 - [Model Context Protocol - Documentation](https://modelcontextprotocol.io)
 - [Model Context Protocol - TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
-- [ModelFetch - Website](https://preview.modelfetch.com)
-- [ModelFetch - Documentation](https://preview.modelfetch.com/docs)
+- [ModelFetch - Website](https://www.modelfetch.com)
+- [ModelFetch - Documentation](https://www.modelfetch.com/docs)
 - [ModelFetch - GitHub](https://github.com/phuctm97/modelfetch)

--- a/libs/modelfetch-bun/README.md
+++ b/libs/modelfetch-bun/README.md
@@ -115,7 +115,7 @@ bun run dist/index.js
 
 ## Documentation
 
-For complete documentation, examples, and guides, visit [preview.modelfetch.com/docs/runtimes/bun](https://preview.modelfetch.com/docs/runtimes/bun).
+For complete documentation, examples, and guides, visit [www.modelfetch.com/docs/runtimes/bun](https://www.modelfetch.com/docs/runtimes/bun).
 
 ## License
 

--- a/libs/modelfetch-core/README.md
+++ b/libs/modelfetch-core/README.md
@@ -16,7 +16,7 @@ To build MCP servers with ModelFetch, use one of the following runtime-specific 
 
 ## Documentation
 
-For complete documentation and examples, visit [preview.modelfetch.com](https://preview.modelfetch.com).
+For complete documentation and examples, visit [www.modelfetch.com](https://www.modelfetch.com).
 
 ## License
 

--- a/libs/modelfetch-deno/README.md
+++ b/libs/modelfetch-deno/README.md
@@ -140,7 +140,7 @@ Optional `deno.json`:
 
 ## Documentation
 
-For complete documentation, examples, and guides, visit [preview.modelfetch.com/docs/runtimes/deno](https://preview.modelfetch.com/docs/runtimes/deno).
+For complete documentation, examples, and guides, visit [www.modelfetch.com/docs/runtimes/deno](https://www.modelfetch.com/docs/runtimes/deno).
 
 ## License
 

--- a/libs/modelfetch-node/README.md
+++ b/libs/modelfetch-node/README.md
@@ -119,7 +119,7 @@ node dist/index.js
 
 ## Documentation
 
-For complete documentation, examples, and guides, visit [preview.modelfetch.com/docs/runtimes/node](https://preview.modelfetch.com/docs/runtimes/node).
+For complete documentation, examples, and guides, visit [www.modelfetch.com/docs/runtimes/node](https://www.modelfetch.com/docs/runtimes/node).
 
 ## License
 


### PR DESCRIPTION
## Summary
- Updated all documentation URLs from `preview.modelfetch.com` to `www.modelfetch.com`
- Updated 20 occurrences across 12 files
- Created version plan for patch release

## Changes
- Main README.md - 2 URLs
- Create-modelfetch CLI output - 1 URL
- Template README files (6 files) - 3 URLs each
- Library README files (4 files) - 1 URL each

## Test plan
- [x] All URLs have been updated
- [x] No remaining references to preview.modelfetch.com
- [x] Code formatting, type checking, and linting pass

🤖 Generated with [Claude Code](https://claude.ai/code)