### PR TITLE
Enhance create-modelfetch CLI with improved DX and runtime detection

### DIFF
--- a/.nx/version-plans/improve-create-modelfetch-cli.md
+++ b/.nx/version-plans/improve-create-modelfetch-cli.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Improve create-modelfetch CLI with tslib dependency, yarn output fix, Deno runtime detection, and updated MCP Inspector command

--- a/libs/create-modelfetch/README.md
+++ b/libs/create-modelfetch/README.md
@@ -11,19 +11,49 @@
 Using **npx**:
 
 ```bash
-npx create-modelfetch@latest
+npx -y create-modelfetch@latest
 ```
 
-Using **pnpm**:
+Using **npm init**:
+
+```bash
+npm init modelfetch@latest
+```
+
+Using **npm create**:
+
+```bash
+npm create modelfetch@latest
+```
+
+Using **pnpm dlx**:
+
+```bash
+pnpm dlx create-modelfetch@latest
+```
+
+Using **pnpm create**:
 
 ```bash
 pnpm create modelfetch@latest
 ```
 
-Using **bun**:
+Using **bun x**:
+
+```bash
+bun x create-modelfetch@latest
+```
+
+Using **bun create**:
 
 ```bash
 bun create modelfetch@latest
+```
+
+Using **deno**:
+
+```bash
+deno run -A npm:create-modelfetch@latest
 ```
 
 Using **yarn**:
@@ -35,10 +65,12 @@ yarn create modelfetch
 ## Features
 
 - **Multiple Runtimes**: Node.js, Bun, and Deno
-- **Multiple Languages**: TypeScript or JavaScript
+- **Multiple Languages**: TypeScript and JavaScript
+- **Multiple Package Managers**: `npm`, `pnpm`, `bun`, `deno`, and `yarn`
+- **Multiple CLI Initializers**: `npx`, `npm init`, `npm create`, `pnpm dlx`, `pnpm create`, `bun x`, `bun create`, `deno`, and `yarn`
 - **Interactive Setup**: Interactively creates and configures your project based on your preferences
-- **Package Manager Detection**: Automatically detects and suggests your preferred package manager
-- **Dependency Installation**: Automatically installs dependencies using your preferred package manager
+- **Automatic Detection**: Automatically detects and suggests your preferred package manager
+- **Automatic Installation**: Automatically installs dependencies using your preferred package manager
 
 ## License
 

--- a/libs/create-modelfetch/templates/bun-js/README.md.template
+++ b/libs/create-modelfetch/templates/bun-js/README.md.template
@@ -17,7 +17,7 @@ bun start
 In a separate terminal, run the MCP Inspector to test your server:
 
 ```bash
-npx @modelcontextprotocol/inspector
+npx -y @modelcontextprotocol/inspector@latest
 ```
 
 Then, connect to your server at `http://localhost:3000/mcp` (or the endpoint shown in your server output).

--- a/libs/create-modelfetch/templates/bun-js/package.json.template
+++ b/libs/create-modelfetch/templates/bun-js/package.json.template
@@ -11,6 +11,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "<%= versions['@modelcontextprotocol/sdk'] %>",
     "@modelfetch/bun": "<%= versions['@modelfetch/bun'] %>",
+    "tslib": "<%= versions['tslib'] %>",
     "zod": "<%= versions['zod'] %>"
   }
 }

--- a/libs/create-modelfetch/templates/bun-ts/README.md.template
+++ b/libs/create-modelfetch/templates/bun-ts/README.md.template
@@ -17,7 +17,7 @@ bun start
 In a separate terminal, run the MCP Inspector to test your server:
 
 ```bash
-npx @modelcontextprotocol/inspector
+npx -y @modelcontextprotocol/inspector@latest
 ```
 
 Then, connect to your server at `http://localhost:3000/mcp` (or the endpoint shown in your server output).

--- a/libs/create-modelfetch/templates/bun-ts/package.json.template
+++ b/libs/create-modelfetch/templates/bun-ts/package.json.template
@@ -11,6 +11,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "<%= versions['@modelcontextprotocol/sdk'] %>",
     "@modelfetch/bun": "<%= versions['@modelfetch/bun'] %>",
+    "tslib": "<%= versions['tslib'] %>",
     "zod": "<%= versions['zod'] %>"
   },
   "devDependencies": {

--- a/libs/create-modelfetch/templates/deno-js/README.md.template
+++ b/libs/create-modelfetch/templates/deno-js/README.md.template
@@ -17,7 +17,7 @@ deno task start
 In a separate terminal, run the MCP Inspector to test your server:
 
 ```bash
-npx @modelcontextprotocol/inspector
+npx -y @modelcontextprotocol/inspector@latest
 ```
 
 Then, connect to your server at `http://localhost:3000/mcp` (or the endpoint shown in your server output).

--- a/libs/create-modelfetch/templates/deno-js/deno.json.template
+++ b/libs/create-modelfetch/templates/deno-js/deno.json.template
@@ -1,9 +1,8 @@
 {
-  "name": "<%= projectName %>",
-  "version": "0.0.1",
   "imports": {
     "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@<%= versions['@modelcontextprotocol/sdk'] %>",
     "@modelfetch/deno": "npm:@modelfetch/deno@<%= versions['@modelfetch/deno'] %>",
+    "tslib": "npm:tslib@<%= versions['tslib'] %>",
     "zod": "npm:zod@<%= versions['zod'] %>"
   },
   "tasks": {

--- a/libs/create-modelfetch/templates/deno-js/src/server.js.template
+++ b/libs/create-modelfetch/templates/deno-js/src/server.js.template
@@ -1,12 +1,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import denoJson from "../deno.json" with { type: "json" };
-
 const server = new McpServer({
   title: "<%= projectTitle %>",
-  name: denoJson.name,
-  version: denoJson.version,
+  name: "<%= projectName %>",
+  version: "0.0.1",
 });
 
 // Example tool: Roll Dice

--- a/libs/create-modelfetch/templates/deno-ts/README.md.template
+++ b/libs/create-modelfetch/templates/deno-ts/README.md.template
@@ -17,7 +17,7 @@ deno task start
 In a separate terminal, run the MCP Inspector to test your server:
 
 ```bash
-npx @modelcontextprotocol/inspector
+npx -y @modelcontextprotocol/inspector@latest
 ```
 
 Then, connect to your server at `http://localhost:3000/mcp` (or the endpoint shown in your server output).

--- a/libs/create-modelfetch/templates/deno-ts/deno.json.template
+++ b/libs/create-modelfetch/templates/deno-ts/deno.json.template
@@ -1,9 +1,8 @@
 {
-  "name": "<%= projectName %>",
-  "version": "0.0.1",
   "imports": {
     "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@<%= versions['@modelcontextprotocol/sdk'] %>",
     "@modelfetch/deno": "npm:@modelfetch/deno@<%= versions['@modelfetch/deno'] %>",
+    "tslib": "npm:tslib@<%= versions['tslib'] %>",
     "zod": "npm:zod@<%= versions['zod'] %>"
   },
   "tasks": {

--- a/libs/create-modelfetch/templates/deno-ts/src/server.ts.template
+++ b/libs/create-modelfetch/templates/deno-ts/src/server.ts.template
@@ -1,12 +1,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import denoJson from "../deno.json" with { type: "json" };
-
 const server = new McpServer({
   title: "<%= projectTitle %>",
-  name: denoJson.name,
-  version: denoJson.version,
+  name: "<%= projectName %>",
+  version: "0.0.1",
 });
 
 // Example tool: Roll Dice

--- a/libs/create-modelfetch/templates/node-js/README.md.template
+++ b/libs/create-modelfetch/templates/node-js/README.md.template
@@ -17,7 +17,7 @@ Start the MCP server:
 In a separate terminal, run the MCP Inspector to test your server:
 
 ```bash
-npx @modelcontextprotocol/inspector
+npx -y @modelcontextprotocol/inspector@latest
 ```
 
 Then, connect to your server at `http://localhost:3000/mcp` (or the endpoint shown in your server output).

--- a/libs/create-modelfetch/templates/node-js/package.json.template
+++ b/libs/create-modelfetch/templates/node-js/package.json.template
@@ -11,6 +11,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "<%= versions['@modelcontextprotocol/sdk'] %>",
     "@modelfetch/node": "<%= versions['@modelfetch/node'] %>",
+    "tslib": "<%= versions['tslib'] %>",
     "zod": "<%= versions['zod'] %>"
   }
 }

--- a/libs/create-modelfetch/templates/node-ts/README.md.template
+++ b/libs/create-modelfetch/templates/node-ts/README.md.template
@@ -17,7 +17,7 @@ Start the MCP server:
 In a separate terminal, run the MCP Inspector to test your server:
 
 ```bash
-npx @modelcontextprotocol/inspector
+npx -y @modelcontextprotocol/inspector@latest
 ```
 
 Then, connect to your server at `http://localhost:3000/mcp` (or the endpoint shown in your server output).


### PR DESCRIPTION
## Summary
- Add tslib dependency to all project templates for proper TypeScript helper support
- Fix yarn console output timing issue with 500ms delay to prevent UI conflicts
- Auto-detect Deno runtime when CLI is invoked via 'deno run' command
- Update MCP Inspector command to use -y flag and @latest tag for smoother setup
- Simplify Deno templates by removing unnecessary config fields
- Expand documentation with comprehensive initialization methods

## Test plan
- [x] Test `yarn create modelfetch` - verify no console output conflicts
- [x] Test `deno run -A npm:create-modelfetch@latest` - verify Deno is auto-selected
- [x] Test all template types (node-js, node-ts, bun-js, bun-ts, deno-js, deno-ts) - verify tslib is included
- [x] Test MCP Inspector command from generated projects - verify it uses `-y` and `@latest`
- [x] Verify Deno templates work without name/version/exports fields in deno.json

🤖 Generated with [Claude Code](https://claude.ai/code)