### PR TITLE
Add prepare-release-publish executor for cleaner npm packages

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,6 +25,7 @@ jobs:
           registry-url: https://registry.npmjs.org
       - run: pnpm install
       - run: pnpm exec nx run-many -t typecheck lint build
+      - run: pnpm exec nx run-many -t prepare-release-publish
       - run: pnpm exec nx release publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.nx/version-plans/add-prepare-release-publish-executor.md
+++ b/.nx/version-plans/add-prepare-release-publish-executor.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Add prepare-release-publish executor to clean package.json files before npm publishing

--- a/libs/create-modelfetch/templates/cloudflare-ts/src/index.ts.template
+++ b/libs/create-modelfetch/templates/cloudflare-ts/src/index.ts.template
@@ -1,6 +1,6 @@
 import handle from "@modelfetch/cloudflare";
 
-import server from "./server.js";
+import server from "./server";
 
 export default {
   fetch: handle(server),

--- a/libs/create-modelfetch/templates/vercel-js/app/[[...path]]/server.js.template
+++ b/libs/create-modelfetch/templates/vercel-js/app/[[...path]]/server.js.template
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import packageJson from "../package.json" with { type: "json" };
+import packageJson from "../../package.json" with { type: "json" };
 
 const server = new McpServer({
   title: "<%= projectTitle %>",

--- a/libs/create-modelfetch/templates/vercel-ts/app/[[...path]]/server.ts.template
+++ b/libs/create-modelfetch/templates/vercel-ts/app/[[...path]]/server.ts.template
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import packageJson from "../package.json" with { type: "json" };
+import packageJson from "../../package.json" with { type: "json" };
 
 const server = new McpServer({
   title: "<%= projectTitle %>",

--- a/libs/nx-10x/package.json
+++ b/libs/nx-10x/package.json
@@ -12,5 +12,6 @@
     "create-eslint-config": "workspace:^",
     "type-fest": "^4.41.0"
   },
+  "executors": "./src/executors/index.json",
   "generators": "./src/generators/index.json"
 }

--- a/libs/nx-10x/src/executors/index.json
+++ b/libs/nx-10x/src/executors/index.json
@@ -1,0 +1,9 @@
+{
+  "executors": {
+    "prepare-release-publish": {
+      "description": "Prepare for release publishing.",
+      "implementation": "./prepare-release-publish/index.ts",
+      "schema": "./prepare-release-publish/schema.json"
+    }
+  }
+}

--- a/libs/nx-10x/src/executors/prepare-release-publish/index.ts
+++ b/libs/nx-10x/src/executors/prepare-release-publish/index.ts
@@ -1,0 +1,38 @@
+import type { ExecutorContext } from "@nx/devkit";
+import type { PackageJson } from "type-fest";
+
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export default async function prepareReleasePublish(
+  options: object,
+  context: ExecutorContext,
+): Promise<{ success: boolean }> {
+  if (!context.projectName) return { success: false };
+  const project = context.projectsConfigurations.projects[context.projectName];
+  const packageJson = JSON.parse(
+    await readFile(
+      path.join(context.root, project.root, "package.json"),
+      "utf8",
+    ),
+  ) as PackageJson;
+  for (const key of ["scripts", "devDependencies"])
+    if (key in packageJson) delete packageJson[key];
+  const exportEntries = [packageJson.exports];
+  while (exportEntries.length > 0) {
+    const exportEntry = exportEntries.pop();
+    if (exportEntry) {
+      if (Array.isArray(exportEntry)) {
+        exportEntries.push(...exportEntry);
+      } else if (typeof exportEntry === "object") {
+        if ("development" in exportEntry) delete exportEntry.development;
+        exportEntries.push(...Object.values(exportEntry));
+      }
+    }
+  }
+  await writeFile(
+    path.join(context.root, project.root, "package.json"),
+    JSON.stringify(packageJson),
+  );
+  return { success: true };
+}

--- a/libs/nx-10x/src/executors/prepare-release-publish/schema.json
+++ b/libs/nx-10x/src/executors/prepare-release-publish/schema.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/libs/nx-10x/src/index.ts
+++ b/libs/nx-10x/src/index.ts
@@ -169,6 +169,11 @@ export const createNodesV2: CreateNodesV2 = [
             };
           }
         }
+        if (!packageJson.private) {
+          targets["prepare-release-publish"] = {
+            executor: "nx-10x:prepare-release-publish",
+          };
+        }
         return { projects: { [projectRoot]: { projectType, targets } } };
       },
       packageJsonFilePaths,


### PR DESCRIPTION
## Summary

- Adds a new `prepare-release-publish` Nx executor that cleans package.json files before npm publishing
- Integrates the executor into the GitHub publish workflow
- Fixes import paths in create-modelfetch templates

## Details

The new executor removes development-only content from package.json files to ensure cleaner production packages:
- Removes `scripts` and `devDependencies` sections
- Removes `development` condition from export entries
- Automatically runs on all non-private packages during the publish process

This improves the quality of published packages by excluding unnecessary development dependencies and scripts that end users don't need.

## Test plan

- [ ] Verify the executor runs successfully in the publish workflow
- [ ] Check that published packages have cleaned package.json files
- [ ] Ensure create-modelfetch templates work correctly with fixed import paths

🤖 Generated with [Claude Code](https://claude.ai/code)