### PR TITLE
Fix Netlify import map syntax for npm URL format

### DIFF
--- a/.nx/version-plans/fix-netlify-import-map-syntax.json
+++ b/.nx/version-plans/fix-netlify-import-map-syntax.json
@@ -1,0 +1,8 @@
+{
+  "versionPlans": {
+    "create-modelfetch": {
+      "version": "0.12.2",
+      "changelog": "Fix import map syntax for Netlify templates to use correct npm: URL format"
+    }
+  }
+}

--- a/libs/create-modelfetch/templates/netlify-js/import_map.json.template
+++ b/libs/create-modelfetch/templates/netlify-js/import_map.json.template
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@modelcontextprotocol/sdk/": "npm:@modelcontextprotocol/sdk@<%= versions['@modelcontextprotocol/sdk'] %>/",
+    "@modelcontextprotocol/sdk/": "npm:/@modelcontextprotocol/sdk@<%= versions['@modelcontextprotocol/sdk'] %>/",
     "@modelfetch/netlify": "npm:@modelfetch/netlify@<%= versions['@modelfetch/netlify'] %>",
     "tslib": "npm:tslib@<%= versions['tslib'] %>",
     "zod": "npm:zod@<%= versions['zod'] %>"

--- a/libs/create-modelfetch/templates/netlify-ts/import_map.json.template
+++ b/libs/create-modelfetch/templates/netlify-ts/import_map.json.template
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@modelcontextprotocol/sdk/": "npm:@modelcontextprotocol/sdk@<%= versions['@modelcontextprotocol/sdk'] %>/",
+    "@modelcontextprotocol/sdk/": "npm:/@modelcontextprotocol/sdk@<%= versions['@modelcontextprotocol/sdk'] %>/",
     "@modelfetch/netlify": "npm:@modelfetch/netlify@<%= versions['@modelfetch/netlify'] %>",
     "tslib": "npm:tslib@<%= versions['tslib'] %>",
     "zod": "npm:zod@<%= versions['zod'] %>"


### PR DESCRIPTION
## Summary
- Fixed the npm import syntax in Netlify templates by adding a leading slash to the npm URL format
- Changed from `npm:@modelcontextprotocol/sdk@` to `npm:/@modelcontextprotocol/sdk@` for the trailing slash entry
- This follows the Import Maps Standard requirement for modules with nested imports

## Test plan
- [x] Verify that `create-modelfetch` generates correct import_map.json for Netlify templates
- [x] Test that Netlify projects can properly import nested modules from `@modelcontextprotocol/sdk/`
- [x] Ensure the generated import maps follow the Import Maps Standard

🤖 Generated with [Claude Code](https://claude.ai/code)