### PR TITLE
Add Next.js runtime adapter for ModelFetch

### DIFF
--- a/.nx/version-plans/add-next-runtime-adapter.md
+++ b/.nx/version-plans/add-next-runtime-adapter.md
@@ -1,5 +1,5 @@
 ---
-__default__: minor
+__default__: patch
 ---
 
-Add Next.js runtime adapter for deploying MCP servers to Next.js applications
+Add Next.js runtime adapter (alpha)

--- a/.nx/version-plans/add-next-runtime-adapter.md
+++ b/.nx/version-plans/add-next-runtime-adapter.md
@@ -1,0 +1,5 @@
+---
+__default__: minor
+---
+
+Add Next.js runtime adapter for deploying MCP servers to Next.js applications

--- a/apps/modelfetch-website/app/page.tsx
+++ b/apps/modelfetch-website/app/page.tsx
@@ -132,16 +132,7 @@ export default function Page() {
                   </h3>
                   <p className="text-gray-600 dark:text-gray-400">
                     Write your MCP server once. Run it anywhere: Node.js, Bun,
-                    Deno, AWS Lambda, Vercel, Cloudflare, Netlify, etc.
-                  </p>
-                </div>
-                <div className="group rounded border border-gray-300 bg-white p-4 shadow-md transition-all hover:border-[#008f00] hover:shadow-[0_0_20px_rgba(0,143,0,0.3)] sm:p-6 dark:border-[#333] dark:bg-[#1a1a1a] dark:shadow-none dark:hover:border-[#00ff00] dark:hover:shadow-[0_0_20px_rgba(0,255,0,0.3)]">
-                  <h3 className="mb-3 text-xl font-semibold text-[#008f00] transition-colors group-hover:text-[#0099cc] dark:text-[#00ff00] dark:group-hover:text-[#00ffff]">
-                    <span className="mr-2">◈</span>Delightful DX
-                  </h3>
-                  <p className="text-gray-600 dark:text-gray-400">
-                    Build your MCP server with tools designed for building MCP
-                    servers: live reload, debugger, MCP Inspector, etc.
+                    Deno, Vercel, Cloudflare, Netlify, AWS Lambda.
                   </p>
                 </div>
                 <div className="group rounded border border-gray-300 bg-white p-4 shadow-md transition-all hover:border-[#008f00] hover:shadow-[0_0_20px_rgba(0,143,0,0.3)] sm:p-6 dark:border-[#333] dark:bg-[#1a1a1a] dark:shadow-none dark:hover:border-[#00ff00] dark:hover:shadow-[0_0_20px_rgba(0,255,0,0.3)]">
@@ -151,6 +142,15 @@ export default function Page() {
                   <p className="text-gray-600 dark:text-gray-400">
                     Built on top of the official MCP TypeScript SDK to avoid
                     lock-in and ensure up-to-date implementation.
+                  </p>
+                </div>
+                <div className="group rounded border border-gray-300 bg-white p-4 shadow-md transition-all hover:border-[#008f00] hover:shadow-[0_0_20px_rgba(0,143,0,0.3)] sm:p-6 dark:border-[#333] dark:bg-[#1a1a1a] dark:shadow-none dark:hover:border-[#00ff00] dark:hover:shadow-[0_0_20px_rgba(0,255,0,0.3)]">
+                  <h3 className="mb-3 text-xl font-semibold text-[#008f00] transition-colors group-hover:text-[#0099cc] dark:text-[#00ff00] dark:group-hover:text-[#00ffff]">
+                    <span className="mr-2">◈</span>Delightful DX
+                  </h3>
+                  <p className="text-gray-600 dark:text-gray-400">
+                    Build your MCP server with tools designed for building MCP
+                    servers: live reload, debugger, MCP Inspector, etc.
                   </p>
                 </div>
               </div>

--- a/libs/modelfetch-next/README.md
+++ b/libs/modelfetch-next/README.md
@@ -1,0 +1,71 @@
+# `@modelfetch/next`
+
+[![npm version](https://img.shields.io/npm/v/@modelfetch/next.svg)](https://www.npmjs.com/package/@modelfetch/next)
+[![npm license](https://img.shields.io/npm/l/@modelfetch/next.svg)](https://www.npmjs.com/package/@modelfetch/next)
+[![docs](https://img.shields.io/badge/docs-modelfetch.com-blue)](https://www.modelfetch.com/docs/runtimes/next)
+
+Run flexible MCP servers with Next.js.
+
+## Installation
+
+```npm
+npm install @modelfetch/next
+```
+
+## Usage
+
+### Next.js App Router
+
+```typescript
+import handle from "@modelfetch/next";
+import server from "./server"; // Import your McpServer
+
+const handler = handle(server);
+
+// Export as Next.js App Router API route handlers
+export const GET = handler;
+export const POST = handler;
+export const DELETE = handler;
+```
+
+### Use Node.js Runtime
+
+```typescript
+import handle from "@modelfetch/next";
+import server from "./server"; // Import your McpServer
+
+const handler = handle(server);
+
+// Export as Next.js App Router API route handlers
+export const GET = handler;
+export const POST = handler;
+export const DELETE = handler;
+
+// Use Node.js runtime (default)
+export const runtime = "nodejs";
+```
+
+### Use Edge Runtime
+
+```typescript
+import handle from "@modelfetch/next";
+import server from "./server"; // Import your McpServer
+
+const handler = handle(server);
+
+// Export as Next.js App Router API route handlers
+export const GET = handler;
+export const POST = handler;
+export const DELETE = handler;
+
+// Use Edge runtime
+export const runtime = "edge";
+```
+
+## API Reference
+
+### `handle(server)`
+
+Creates a Next.js App Router API route handler from an [`McpServer`](https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#server)
+
+- **server**: Required [`McpServer`](https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#server) instance from [`@modelcontextprotocol/sdk`](https://github.com/modelcontextprotocol/typescript-sdk)

--- a/libs/modelfetch-next/eslint.config.js
+++ b/libs/modelfetch-next/eslint.config.js
@@ -1,0 +1,5 @@
+import createESLintConfig from "create-eslint-config";
+
+const eslintConfig = createESLintConfig();
+
+export default eslintConfig;

--- a/libs/modelfetch-next/package.json
+++ b/libs/modelfetch-next/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@modelfetch/next",
+  "version": "0.12.2",
+  "description": "Next.js runtime adapter for MCP servers built with ModelFetch",
+  "keywords": [
+    "model-context-protocol",
+    "mcp",
+    "mcp-server",
+    "ai",
+    "ai-integration",
+    "sdk",
+    "typescript-sdk",
+    "javascript-sdk"
+  ],
+  "homepage": "https://www.modelfetch.com",
+  "bugs": {
+    "url": "https://github.com/phuctm97/modelfetch/issues",
+    "email": "phuctm97@gmail.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/phuctm97/modelfetch.git",
+    "directory": "libs/modelfetch-next"
+  },
+  "license": "MIT",
+  "author": {
+    "name": "Minh-Phuc Tran",
+    "email": "phuctm97@gmail.com",
+    "url": "https://x.com/phuctm97"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@modelfetch/core": "workspace:^",
+    "hono": "^4.8.4"
+  },
+  "devDependencies": {
+    "create-eslint-config": "workspace:^"
+  }
+}

--- a/libs/modelfetch-next/src/index.ts
+++ b/libs/modelfetch-next/src/index.ts
@@ -1,0 +1,9 @@
+import type { ServerOrConfig } from "@modelfetch/core";
+
+import { createApp } from "@modelfetch/core";
+import { handle as handler } from "hono/vercel";
+
+export default function handle(arg: ServerOrConfig) {
+  const app = createApp(arg);
+  return handler(app);
+}

--- a/libs/modelfetch-next/tsconfig.json
+++ b/libs/modelfetch-next/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "../modelfetch-core"
+    }
+  ],
+  "extends": "../../tsconfig.base.json"
+}

--- a/libs/modelfetch-next/tsconfig.lib.json
+++ b/libs/modelfetch-next/tsconfig.lib.json
@@ -1,0 +1,14 @@
+{
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../modelfetch-core/tsconfig.lib.json"
+    }
+  ],
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "sourceRoot": "/libs/modelfetch-next/src",
+    "rootDir": "src",
+    "outDir": "dist"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -602,6 +602,19 @@ importers:
         specifier: workspace:^
         version: link:../create-eslint-config
 
+  libs/modelfetch-next:
+    dependencies:
+      '@modelfetch/core':
+        specifier: workspace:^
+        version: link:../modelfetch-core
+      hono:
+        specifier: ^4.8.4
+        version: 4.8.4
+    devDependencies:
+      create-eslint-config:
+        specifier: workspace:^
+        version: link:../create-eslint-config
+
   libs/modelfetch-node:
     dependencies:
       '@hono/node-server':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -50,6 +50,9 @@
       "path": "./libs/modelfetch-netlify"
     },
     {
+      "path": "./libs/modelfetch-next"
+    },
+    {
       "path": "./libs/modelfetch-node"
     },
     {


### PR DESCRIPTION
## Summary
- Introduces new `@modelfetch/next` package for deploying MCP servers to Next.js applications
- Wraps core ModelFetch functionality with Hono's Vercel handler for seamless Next.js API route integration
- Reorders homepage feature cards to prioritize the official SDK foundation

## Test plan
- [x] Build and type check pass for the new package
- [x] Integration with Next.js API routes works correctly
- [x] Package exports are properly configured
- [x] Website homepage displays updated feature order

🤖 Generated with [Claude Code](https://claude.ai/code)