### PR TITLE
Add Next.js templates to create-modelfetch CLI

### DIFF
--- a/.nx/version-plans/add-nextjs-templates.md
+++ b/.nx/version-plans/add-nextjs-templates.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Add Next.js templates to create-modelfetch CLI

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## 🚀 Features
 
-- **Multi-Runtime**: Write once, run anywhere: Node.js, Bun, Deno, AWS Lambda, Vercel, Cloudflare, Netlify, etc.
+- **Multi-Runtime**: Write once, run anywhere: Node.js, Next.js, Bun, Deno, AWS Lambda, Vercel, Cloudflare, Netlify, etc.
 - **Official SDK**: Built on top of the [official MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk) to avoid lock-in, guarantee long-term support, and ensure up-to-date implementation
 - **Live Reload**: Development server with automatic reloading
 - **MCP Inspector**: Built-in integration for testing and debugging
@@ -77,6 +77,19 @@ import handle from "@modelfetch/node"; // Choose your runtime
 import server from "./server"; // Import your server
 
 handle(server); // Let ModelFetch handle all runtime-specific details
+```
+
+#### Next.js
+
+```typescript
+import handle from "@modelfetch/next"; // Choose your runtime
+import server from "./server"; // Import your server
+
+const handler = handle(server); // Let ModelFetch handle all runtime-specific details
+
+export const GET = handler;
+export const POST = handler;
+export const DELETE = handler;
 ```
 
 #### Bun
@@ -159,6 +172,7 @@ ModelFetch provides runtime-specific packages that handle tedious platform diffe
 | Package                                                | Description                             | Status   |
 | ------------------------------------------------------ | --------------------------------------- | -------- |
 | [`@modelfetch/node`](libs/modelfetch-node)             | Run simple MCP servers with Node.js     | ✅ Ready |
+| [`@modelfetch/next`](libs/modelfetch-next)             | Run flexible MCP servers with Next.js   | ✅ Ready |
 | [`@modelfetch/bun`](libs/modelfetch-bun)               | Run lightning-fast MCP servers with Bun | ✅ Ready |
 | [`@modelfetch/deno`](libs/modelfetch-deno)             | Run secure MCP servers with Deno        | ✅ Ready |
 | [`@modelfetch/aws-lambda`](libs/modelfetch-aws-lambda) | Deploy MCP servers to AWS Lambda        | ✅ Ready |

--- a/apps/modelfetch-website/mdx/index.mdx
+++ b/apps/modelfetch-website/mdx/index.mdx
@@ -57,6 +57,17 @@ import server from "./server"; // Import your server
 handle(server); // That's it — ModelFetch handles all runtime-specific details
 ```
 
+```typescript title="app/[[...path]]/route.ts" tab="Next.js"
+import handle from "@modelfetch/next"; // Choose your runtime
+import server from "./server"; // Import your server
+
+const handler = handle(server); // That's it — ModelFetch handles all runtime-specific details
+
+export const GET = handler;
+export const POST = handler;
+export const DELETE = handler;
+```
+
 ```typescript title="src/index.ts" tab="Bun"
 import handle from "@modelfetch/bun"; // Choose your runtime
 import server from "./server.ts"; // Import your server
@@ -122,6 +133,17 @@ import server from "./server"; // Import your server
 handle(server); // Let ModelFetch handle all runtime-specific details
 ```
 
+```typescript title="app/[[...path]]/route.ts" tab="Next.js"
+import handle from "@modelfetch/next"; // Choose your runtime
+import server from "./server"; // Import your server
+
+const handler = handle(server); // Let ModelFetch handle all runtime-specific details
+
+export const GET = handler;
+export const POST = handler;
+export const DELETE = handler;
+```
+
 ```typescript title="src/index.ts" tab="Bun"
 import handle from "@modelfetch/bun"; // Choose your runtime
 import server from "./server.ts"; // Import your server
@@ -185,7 +207,7 @@ export default handle(server); // Let ModelFetch handle all runtime-specific det
   />
   <Card
     title="Runtime"
-    description="Explore runtime-specific guides for Node.js, Bun, Deno, AWS Lambda, Vercel, Cloudflare, and Netlify"
+    description="Explore runtime-specific guides for Node.js, Next.js, Bun, Deno, AWS Lambda, Vercel, Cloudflare, and Netlify"
     href="/docs/runtime"
   />
 </Cards>

--- a/apps/modelfetch-website/mdx/quick-start.mdx
+++ b/apps/modelfetch-website/mdx/quick-start.mdx
@@ -13,7 +13,7 @@ npx -y create-modelfetch@latest
 
 The CLI will guide you through:
 
-1. **Choosing a runtime** - Node.js, Bun, Deno, AWS Lambda, Vercel, Cloudflare, or Netlify
+1. **Choosing a runtime** - Node.js, Next.js, Bun, Deno, AWS Lambda, Vercel, Cloudflare, or Netlify
 2. **Selecting a language** - TypeScript or JavaScript
 3. **Picking a package manager** - npm, pnpm, bun, or yarn
 
@@ -23,6 +23,10 @@ If you prefer to set up manually, install the ModelFetch package for your runtim
 
 ```npm title="Terminal" tab="Node.js"
 npm install @modelfetch/node
+```
+
+```npm title="Terminal" tab="Next.js"
+npm install @modelfetch/next
 ```
 
 ```bash title="Terminal" tab="Bun"
@@ -96,6 +100,17 @@ import server from "./server"; // Import your server
 handle(server); // Let ModelFetch handle all runtime-specific details
 ```
 
+```typescript title="app/[[...path]]/route.ts" tab="Next.js"
+import handle from "@modelfetch/next"; // Choose your runtime
+import server from "./server"; // Import your server
+
+const handler = handle(server); // Let ModelFetch handle all runtime-specific details
+
+export const GET = handler;
+export const POST = handler;
+export const DELETE = handler;
+```
+
 ```typescript title="src/index.ts" tab="Bun"
 import handle from "@modelfetch/bun"; // Choose your runtime
 import server from "./server.ts"; // Import your server
@@ -159,7 +174,7 @@ export default handle(server); // Let ModelFetch handle all runtime-specific det
   />
   <Card
     title="Runtime"
-    description="Explore runtime-specific guides for Node.js, Bun, Deno, AWS Lambda, Vercel, Cloudflare, and Netlify"
+    description="Explore runtime-specific guides for Node.js, Next.js, Bun, Deno, AWS Lambda, Vercel, Cloudflare, and Netlify"
     href="/docs/runtime"
   />
 </Cards>

--- a/apps/modelfetch-website/mdx/runtime/index.mdx
+++ b/apps/modelfetch-website/mdx/runtime/index.mdx
@@ -14,6 +14,11 @@ ModelFetch provides runtime-specific packages that handle tedious platform diffe
     href="/docs/runtime/node"
   />
   <Card
+    title="Next.js"
+    description="Run flexible MCP servers with Next.js"
+    href="/docs/runtime/next"
+  />
+  <Card
     title="Bun"
     description="Run lightning-fast MCP servers with Bun"
     href="/docs/runtime/bun"

--- a/apps/modelfetch-website/mdx/runtime/meta.json
+++ b/apps/modelfetch-website/mdx/runtime/meta.json
@@ -2,6 +2,7 @@
   "title": "Runtime",
   "pages": [
     "node",
+    "next",
     "bun",
     "deno",
     "aws-lambda",

--- a/apps/modelfetch-website/mdx/runtime/next.mdx
+++ b/apps/modelfetch-website/mdx/runtime/next.mdx
@@ -1,0 +1,70 @@
+---
+title: Next.js
+description: Run flexible MCP servers with Next.js
+---
+
+The `@modelfetch/next` package lets you run MCP servers as Next.js App Router API route handlers.
+
+## Installation
+
+```npm title="Terminal"
+npm install @modelfetch/next
+```
+
+## Usage
+
+### Next.js App Router
+
+```typescript title="app/[[...path]]/route.ts"
+import handle from "@modelfetch/next";
+import server from "./server"; // Import your McpServer
+
+const handler = handle(server);
+
+// Export as Next.js App Router API route handlers
+export const GET = handler;
+export const POST = handler;
+export const DELETE = handler;
+```
+
+### Use Node.js Runtime
+
+```typescript title="app/[[...path]]/route.ts"
+import handle from "@modelfetch/next";
+import server from "./server"; // Import your McpServer
+
+const handler = handle(server);
+
+// Export as Next.js App Router API route handlers
+export const GET = handler;
+export const POST = handler;
+export const DELETE = handler;
+
+// Use Node.js runtime (default)
+export const runtime = "nodejs";
+```
+
+### Use Edge Runtime
+
+```typescript title="app/[[...path]]/route.ts"
+import handle from "@modelfetch/next";
+import server from "./server"; // Import your McpServer
+
+const handler = handle(server);
+
+// Export as Next.js App Router API route handlers
+export const GET = handler;
+export const POST = handler;
+export const DELETE = handler;
+
+// Use Edge runtime
+export const runtime = "edge";
+```
+
+## API Reference
+
+### `handle(server)`
+
+Creates a Next.js App Router API route handler from an [`McpServer`](https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#server)
+
+- **server**: Required [`McpServer`](https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#server) instance from [`@modelcontextprotocol/sdk`](https://github.com/modelcontextprotocol/typescript-sdk)

--- a/libs/create-modelfetch/README.md
+++ b/libs/create-modelfetch/README.md
@@ -7,7 +7,7 @@ Scaffold a new MCP server with ModelFetch.
 
 ## Features
 
-- **Multiple Runtimes**: Node.js, Bun, Deno, AWS Lambda, Vercel, Cloudflare, and Netlify
+- **Multiple Runtimes**: Node.js, Next.js, Bun, Deno, AWS Lambda, Vercel, Cloudflare, and Netlify
 - **Multiple Languages**: TypeScript and JavaScript
 - **Multiple Package Managers**: `npm`, `pnpm`, `bun`, and `yarn`
 - **Multiple CLI Initializers**: `npx`, `npm init`, `npm create`, `pnpm dlx`, `pnpm create`, `bun x`, `bun create`, `deno`, and `yarn`

--- a/libs/create-modelfetch/src/index.ts
+++ b/libs/create-modelfetch/src/index.ts
@@ -29,6 +29,7 @@ const packageVersions = {
   "@modelfetch/node": packageJson.version,
   "@types/node": "22.16.4",
   tsx: "4.20.3",
+  "@modelfetch/next": packageJson.version,
   "@modelfetch/bun": packageJson.version,
   "@types/bun": "1.2.18",
   "@modelfetch/deno": packageJson.version,
@@ -53,6 +54,7 @@ const cloudflareCompatibilityDate = "2025-06-17";
 
 type Runtime =
   | "node"
+  | "next"
   | "bun"
   | "deno"
   | "aws-lambda"
@@ -122,6 +124,7 @@ function getStartCommand(
     case "aws-lambda": {
       return `${packageManager} run deploy`;
     }
+    case "next":
     case "vercel":
     case "cloudflare": {
       return `${packageManager} run dev`;
@@ -239,6 +242,7 @@ async function main() {
     message: "Which runtime would you like to use?",
     options: [
       { value: "node", label: "Node.js" },
+      { value: "next", label: "Next.js" },
       { value: "bun", label: "Bun" },
       { value: "deno", label: "Deno" },
       { value: "aws-lambda", label: "AWS Lambda" },

--- a/libs/create-modelfetch/templates/next-js/.gitignore.template
+++ b/libs/create-modelfetch/templates/next-js/.gitignore.template
@@ -1,0 +1,6 @@
+.DS_Store
+node_modules
+.next
+out
+.env*.local
+.vercel

--- a/libs/create-modelfetch/templates/next-js/README.md.template
+++ b/libs/create-modelfetch/templates/next-js/README.md.template
@@ -1,0 +1,118 @@
+# <%= projectTitle %>
+
+An MCP server built with [ModelFetch](https://www.modelfetch.com)
+
+## Quick Start
+
+### Running the MCP server
+
+Start the MCP server:
+
+```bash
+<%= packageManager %> run dev
+```
+
+### Testing with the MCP Inspector
+
+In a separate terminal, run the MCP Inspector to test your server:
+
+```bash
+npx -y @modelcontextprotocol/inspector@latest
+```
+
+Then, connect to your server at `http://localhost:3000/mcp` (or the endpoint shown in your server output).
+
+## Project Structure
+
+```
+<%= projectName %>/
+├── app/
+│   └── [[...path]]/
+│       ├── route.js  # Next.js App Router catch-all API route
+│       └── server.js # MCP server implementation
+├── package.json
+└── README.md
+```
+
+## Adding Features
+
+### Tools
+
+Tools provide executable functions to LLMs:
+
+```javascript
+server.registerTool(
+  "my_tool",
+  {
+    title: "My Tool",
+    description: "What this tool does",
+    inputSchema: { param: z.string() },
+  },
+  ({ param }) => ({
+    content: [
+      {
+        type: "text",
+        text: `Result for ${param}`,
+      },
+    ],
+  }),
+);
+```
+
+### Resources
+
+Resources expose data and content to LLMs:
+
+```javascript
+server.registerResource(
+  "my_resource",
+  "resource://my-resource",
+  {
+    title: "My Resource",
+    description: "What this resource does",
+    mimeType: "text/plain",
+  },
+  (uri) => ({
+    contents: [
+      {
+        uri: uri.href,
+        text: "Content of my resource",
+      },
+    ],
+  }),
+);
+```
+
+### Prompts
+
+Prompts are reusable templates for interacting with LLMs:
+
+```javascript
+server.registerPrompt(
+  "my_prompt",
+  {
+    title: "My Prompt",
+    description: "What this prompt does",
+    argsSchema: { arg: z.string() },
+  },
+  ({ arg }) => ({
+    messages: [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: `Prompt with ${arg}`,
+        },
+      },
+    ],
+  }),
+);
+```
+
+## Reading Docs
+
+- [Model Context Protocol - Documentation](https://modelcontextprotocol.io)
+- [Model Context Protocol - TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
+- [ModelFetch - Website](https://www.modelfetch.com)
+- [ModelFetch - Documentation](https://www.modelfetch.com/docs)
+- [ModelFetch - GitHub](https://github.com/phuctm97/modelfetch)

--- a/libs/create-modelfetch/templates/next-js/app/[[...path]]/route.js.template
+++ b/libs/create-modelfetch/templates/next-js/app/[[...path]]/route.js.template
@@ -1,0 +1,9 @@
+import handle from "@modelfetch/next";
+
+import server from "./server.js";
+
+const handler = handle(server);
+
+export const GET = handler;
+export const POST = handler;
+export const DELETE = handler;

--- a/libs/create-modelfetch/templates/next-js/app/[[...path]]/server.js.template
+++ b/libs/create-modelfetch/templates/next-js/app/[[...path]]/server.js.template
@@ -1,0 +1,70 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import packageJson from "../../package.json" with { type: "json" };
+
+const server = new McpServer({
+  title: "<%= projectTitle %>",
+  name: packageJson.name,
+  version: packageJson.version,
+});
+
+// Example tool: Roll Dice
+server.registerTool(
+  "roll_dice",
+  {
+    title: "Roll Dice",
+    description: "Rolls an N-sided dice",
+    inputSchema: { sides: z.number().int().min(2) },
+  },
+  ({ sides }) => ({
+    content: [
+      {
+        type: "text",
+        text: `🎲 You rolled a ${1 + Math.floor(Math.random() * sides)}!`,
+      },
+    ],
+  }),
+);
+
+// Example resource: App Config
+server.registerResource(
+  "app_config",
+  "app://config",
+  {
+    title: "App Config",
+    description: "Application configuration: API keys and user settings",
+    mimeType: "text/plain",
+  },
+  (uri) => ({
+    contents: [
+      {
+        uri: uri.href,
+        text: "<APP_CONFIG>",
+      },
+    ],
+  }),
+);
+
+// Example prompt: Review Code
+server.registerPrompt(
+  "review_code",
+  {
+    title: "Review Code",
+    description: "Review code for best practices and potential issues",
+    argsSchema: { code: z.string() },
+  },
+  ({ code }) => ({
+    messages: [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: `Please review this code:\n\n${code}`,
+        },
+      },
+    ],
+  }),
+);
+
+export default server;

--- a/libs/create-modelfetch/templates/next-js/package.json.template
+++ b/libs/create-modelfetch/templates/next-js/package.json.template
@@ -1,0 +1,21 @@
+{
+  "name": "<%= projectName %>",
+  "version": "0.0.1",
+  "description": "<%= projectTitle %> (built with ModelFetch)",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "<%= versions['@modelcontextprotocol/sdk'] %>",
+    "@modelfetch/next": "<%= versions['@modelfetch/next'] %>",
+    "next": "<%= versions['next'] %>",
+    "react": "<%= versions['react'] %>",
+    "react-dom": "<%= versions['react-dom'] %>",
+    "tslib": "<%= versions['tslib'] %>",
+    "zod": "<%= versions['zod'] %>"
+  }
+}

--- a/libs/create-modelfetch/templates/next-ts/.gitignore.template
+++ b/libs/create-modelfetch/templates/next-ts/.gitignore.template
@@ -1,0 +1,7 @@
+.DS_Store
+node_modules
+.next
+out
+.env*.local
+.vercel
+*.tsbuildinfo

--- a/libs/create-modelfetch/templates/next-ts/README.md.template
+++ b/libs/create-modelfetch/templates/next-ts/README.md.template
@@ -1,0 +1,119 @@
+# <%= projectTitle %>
+
+An MCP server built with [ModelFetch](https://www.modelfetch.com)
+
+## Quick Start
+
+### Running the MCP server
+
+Start the MCP server:
+
+```bash
+<%= packageManager %> run dev
+```
+
+### Testing with the MCP Inspector
+
+In a separate terminal, run the MCP Inspector to test your server:
+
+```bash
+npx -y @modelcontextprotocol/inspector@latest
+```
+
+Then, connect to your server at `http://localhost:3000/mcp` (or the endpoint shown in your server output).
+
+## Project Structure
+
+```
+<%= projectName %>/
+├── app/
+│   └── [[...path]]/
+│       ├── route.ts  # Next.js App Router catch-all API route
+│       └── server.ts # MCP server implementation
+├── tsconfig.json
+├── package.json
+└── README.md
+```
+
+## Adding Features
+
+### Tools
+
+Tools provide executable functions to LLMs:
+
+```typescript
+server.registerTool(
+  "my_tool",
+  {
+    title: "My Tool",
+    description: "What this tool does",
+    inputSchema: { param: z.string() },
+  },
+  ({ param }) => ({
+    content: [
+      {
+        type: "text",
+        text: `Result for ${param}`,
+      },
+    ],
+  }),
+);
+```
+
+### Resources
+
+Resources expose data and content to LLMs:
+
+```typescript
+server.registerResource(
+  "my_resource",
+  "resource://my-resource",
+  {
+    title: "My Resource",
+    description: "What this resource does",
+    mimeType: "text/plain",
+  },
+  (uri) => ({
+    contents: [
+      {
+        uri: uri.href,
+        text: "Content of my resource",
+      },
+    ],
+  }),
+);
+```
+
+### Prompts
+
+Prompts are reusable templates for interacting with LLMs:
+
+```typescript
+server.registerPrompt(
+  "my_prompt",
+  {
+    title: "My Prompt",
+    description: "What this prompt does",
+    argsSchema: { arg: z.string() },
+  },
+  ({ arg }) => ({
+    messages: [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: `Prompt with ${arg}`,
+        },
+      },
+    ],
+  }),
+);
+```
+
+## Reading Docs
+
+- [Model Context Protocol - Documentation](https://modelcontextprotocol.io)
+- [Model Context Protocol - TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
+- [ModelFetch - Website](https://www.modelfetch.com)
+- [ModelFetch - Documentation](https://www.modelfetch.com/docs)
+- [ModelFetch - GitHub](https://github.com/phuctm97/modelfetch)

--- a/libs/create-modelfetch/templates/next-ts/app/[[...path]]/route.ts.template
+++ b/libs/create-modelfetch/templates/next-ts/app/[[...path]]/route.ts.template
@@ -1,0 +1,9 @@
+import handle from "@modelfetch/next";
+
+import server from "./server";
+
+const handler = handle(server);
+
+export const GET = handler;
+export const POST = handler;
+export const DELETE = handler;

--- a/libs/create-modelfetch/templates/next-ts/app/[[...path]]/server.ts.template
+++ b/libs/create-modelfetch/templates/next-ts/app/[[...path]]/server.ts.template
@@ -1,0 +1,70 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import packageJson from "../../package.json" with { type: "json" };
+
+const server = new McpServer({
+  title: "<%= projectTitle %>",
+  name: packageJson.name,
+  version: packageJson.version,
+});
+
+// Example tool: Roll Dice
+server.registerTool(
+  "roll_dice",
+  {
+    title: "Roll Dice",
+    description: "Rolls an N-sided dice",
+    inputSchema: { sides: z.number().int().min(2) },
+  },
+  ({ sides }) => ({
+    content: [
+      {
+        type: "text",
+        text: `🎲 You rolled a ${1 + Math.floor(Math.random() * sides)}!`,
+      },
+    ],
+  }),
+);
+
+// Example resource: App Config
+server.registerResource(
+  "app_config",
+  "app://config",
+  {
+    title: "App Config",
+    description: "Application configuration: API keys and user settings",
+    mimeType: "text/plain",
+  },
+  (uri) => ({
+    contents: [
+      {
+        uri: uri.href,
+        text: "<APP_CONFIG>",
+      },
+    ],
+  }),
+);
+
+// Example prompt: Review Code
+server.registerPrompt(
+  "review_code",
+  {
+    title: "Review Code",
+    description: "Review code for best practices and potential issues",
+    argsSchema: { code: z.string() },
+  },
+  ({ code }) => ({
+    messages: [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: `Please review this code:\n\n${code}`,
+        },
+      },
+    ],
+  }),
+);
+
+export default server;

--- a/libs/create-modelfetch/templates/next-ts/package.json.template
+++ b/libs/create-modelfetch/templates/next-ts/package.json.template
@@ -1,0 +1,27 @@
+{
+  "name": "<%= projectName %>",
+  "version": "0.0.1",
+  "description": "<%= projectTitle %> (built with ModelFetch)",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "<%= versions['@modelcontextprotocol/sdk'] %>",
+    "@modelfetch/next": "<%= versions['@modelfetch/next'] %>",
+    "next": "<%= versions['next'] %>",
+    "react": "<%= versions['react'] %>",
+    "react-dom": "<%= versions['react-dom'] %>",
+    "tslib": "<%= versions['tslib'] %>",
+    "zod": "<%= versions['zod'] %>"
+  },
+  "devDependencies": {
+    "@types/node": "<%= versions['@types/node'] %>",
+    "@types/react": "<%= versions['@types/react'] %>",
+    "@types/react-dom": "<%= versions['@types/react-dom'] %>",
+    "typescript": "<%= versions['typescript'] %>"
+  }
+}

--- a/libs/create-modelfetch/templates/next-ts/tsconfig.json.template
+++ b/libs/create-modelfetch/templates/next-ts/tsconfig.json.template
@@ -1,0 +1,21 @@
+{
+  "include": ["**/*", "**/*.json", ".next/types/**/*.ts"],
+  "exclude": ["node_modules", "out", "public"],
+  "compilerOptions": {
+    "plugins": [{ "name": "next" }],
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "jsx": "preserve",
+    "target": "es2022",
+    "lib": ["dom", "dom.iterable", "es2023"],
+    "strict": true,
+    "incremental": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "importHelpers": true,
+    "skipLibCheck": true,
+    "allowJs": true,
+    "noEmit": true
+  }
+}

--- a/libs/modelfetch-core/README.md
+++ b/libs/modelfetch-core/README.md
@@ -9,6 +9,7 @@
 **💡 Tip:** Use one of our runtime packages instead:
 
 - [@modelfetch/node](https://www.npmjs.com/package/@modelfetch/node) for Node.js
+- [@modelfetch/next](https://www.npmjs.com/package/@modelfetch/next) for Next.js
 - [@modelfetch/bun](https://www.npmjs.com/package/@modelfetch/bun) for Bun
 - [@modelfetch/deno](https://www.npmjs.com/package/@modelfetch/deno) for Deno
 - [@modelfetch/aws-lambda](https://www.npmjs.com/package/@modelfetch/aws-lambda) for AWS Lambda

--- a/libs/modelfetch/README.md
+++ b/libs/modelfetch/README.md
@@ -9,6 +9,7 @@
 **💡 Tip:** Use one of our runtime packages instead:
 
 - [@modelfetch/node](https://www.npmjs.com/package/@modelfetch/node) for Node.js
+- [@modelfetch/next](https://www.npmjs.com/package/@modelfetch/next) for Next.js
 - [@modelfetch/bun](https://www.npmjs.com/package/@modelfetch/bun) for Bun
 - [@modelfetch/deno](https://www.npmjs.com/package/@modelfetch/deno) for Deno
 - [@modelfetch/aws-lambda](https://www.npmjs.com/package/@modelfetch/aws-lambda) for AWS Lambda


### PR DESCRIPTION
## Summary
- Added JavaScript and TypeScript templates for Next.js runtime support
- Updated create-modelfetch CLI to include Next.js as a runtime option
- Added comprehensive documentation for Next.js runtime usage

## Test plan
- [ ] Test create-modelfetch with Next.js JavaScript template
- [ ] Test create-modelfetch with Next.js TypeScript template
- [ ] Verify generated Next.js apps work correctly
- [ ] Ensure documentation is clear and accurate

🤖 Generated with [Claude Code](https://claude.ai/code)