### PR TITLE
Update AWS Lambda templates and docs for streaming mode

### DIFF
--- a/.nx/version-plans/aws-lambda-streaming-mode.md
+++ b/.nx/version-plans/aws-lambda-streaming-mode.md
@@ -1,5 +1,5 @@
 ---
-__default__: minor
+__default__: patch
 ---
 
 Enable AWS Lambda streaming mode with response streaming support and update templates and documentation

--- a/.nx/version-plans/aws-lambda-streaming-mode.md
+++ b/.nx/version-plans/aws-lambda-streaming-mode.md
@@ -1,0 +1,5 @@
+---
+__default__: minor
+---
+
+Enable AWS Lambda streaming mode with response streaming support and update templates and documentation

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ handle(server); // That's it — ModelFetch handles all runtime-specific details
 import handle from "@modelfetch/aws-lambda"; // Choose your runtime
 import server from "./server"; // Import your server
 
-export const handler: AWSLambda.Handler = handle(server); // That's it — ModelFetch handles all runtime-specific details
+export const handler: AWSLambda.LambdaFunctionURLHandler = handle(server); // That's it — ModelFetch handles all runtime-specific details
 ```
 
 #### Vercel

--- a/apps/example-aws-lambda-js/cdk.js
+++ b/apps/example-aws-lambda-js/cdk.js
@@ -1,5 +1,9 @@
-import { App, CfnOutput, Stack } from "aws-cdk-lib";
-import { FunctionUrlAuthType, Runtime } from "aws-cdk-lib/aws-lambda";
+import { App, CfnOutput, Duration, Stack } from "aws-cdk-lib";
+import {
+  FunctionUrlAuthType,
+  InvokeMode,
+  Runtime,
+} from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 
 class ModelFetchExampleAWSLambdaJavaScriptStack extends Stack {
@@ -9,10 +13,12 @@ class ModelFetchExampleAWSLambdaJavaScriptStack extends Stack {
     const nodejsFunction = new NodejsFunction(this, "NodejsFunction", {
       entry: "./src/index.js",
       runtime: Runtime.NODEJS_22_X,
+      timeout: Duration.minutes(5),
     });
 
     const functionUrl = nodejsFunction.addFunctionUrl({
       authType: FunctionUrlAuthType.NONE,
+      invokeMode: InvokeMode.RESPONSE_STREAM,
     });
 
     new CfnOutput(this, "McpServerUrl", { value: `${functionUrl.url}mcp` });

--- a/apps/example-aws-lambda-ts/cdk.js
+++ b/apps/example-aws-lambda-ts/cdk.js
@@ -1,5 +1,9 @@
-import { App, CfnOutput, Stack } from "aws-cdk-lib";
-import { FunctionUrlAuthType, Runtime } from "aws-cdk-lib/aws-lambda";
+import { App, CfnOutput, Duration, Stack } from "aws-cdk-lib";
+import {
+  FunctionUrlAuthType,
+  InvokeMode,
+  Runtime,
+} from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 
 class ModelFetchExampleAWSLambdaTypeScriptStack extends Stack {
@@ -9,10 +13,12 @@ class ModelFetchExampleAWSLambdaTypeScriptStack extends Stack {
     const nodejsFunction = new NodejsFunction(this, "NodejsFunction", {
       entry: "./src/index.ts",
       runtime: Runtime.NODEJS_22_X,
+      timeout: Duration.minutes(5),
     });
 
     const functionUrl = nodejsFunction.addFunctionUrl({
       authType: FunctionUrlAuthType.NONE,
+      invokeMode: InvokeMode.RESPONSE_STREAM,
     });
 
     new CfnOutput(this, "McpServerUrl", { value: `${functionUrl.url}mcp` });

--- a/apps/example-aws-lambda-ts/src/index.ts
+++ b/apps/example-aws-lambda-ts/src/index.ts
@@ -2,4 +2,4 @@ import handle from "@modelfetch/aws-lambda";
 
 import server from "./server";
 
-export const handler: AWSLambda.Handler = handle(server);
+export const handler: AWSLambda.LambdaFunctionURLHandler = handle(server);

--- a/apps/modelfetch-website/lib/runtime-selector/index.tsx
+++ b/apps/modelfetch-website/lib/runtime-selector/index.tsx
@@ -67,7 +67,7 @@ handle(server);`,
     codeExample: `import handle from "@modelfetch/aws-lambda";
 import server from "./server";
 
-export const handler: AWSLambda.Handler = handle(server);`,
+export const handler: AWSLambda.LambdaFunctionURLHandler = handle(server);`,
   },
   {
     id: "vercel",

--- a/apps/modelfetch-website/mdx/index.mdx
+++ b/apps/modelfetch-website/mdx/index.mdx
@@ -86,7 +86,7 @@ handle(server); // That's it — ModelFetch handles all runtime-specific details
 import handle from "@modelfetch/aws-lambda"; // Choose your runtime
 import server from "./server"; // Import your server
 
-export const handler: AWSLambda.Handler = handle(server); // That's it — ModelFetch handles all runtime-specific details
+export const handler: AWSLambda.LambdaFunctionURLHandler = handle(server); // That's it — ModelFetch handles all runtime-specific details
 ```
 
 ```typescript title="app/[[...path]]/route.ts" tab="Vercel"
@@ -162,7 +162,7 @@ handle(server); // That's it — ModelFetch handles all runtime-specific details
 import handle from "@modelfetch/aws-lambda"; // Choose your runtime
 import server from "./server"; // Import your server
 
-export const handler: AWSLambda.Handler = handle(server); // That's it — ModelFetch handles all runtime-specific details
+export const handler: AWSLambda.LambdaFunctionURLHandler = handle(server); // That's it — ModelFetch handles all runtime-specific details
 ```
 
 ```typescript title="app/[[...path]]/route.ts" tab="Vercel"

--- a/apps/modelfetch-website/mdx/quick-start.mdx
+++ b/apps/modelfetch-website/mdx/quick-start.mdx
@@ -129,7 +129,7 @@ handle(server); // That's it — ModelFetch handles all runtime-specific details
 import handle from "@modelfetch/aws-lambda"; // Choose your runtime
 import server from "./server"; // Import your server
 
-export const handler: AWSLambda.Handler = handle(server); // That's it — ModelFetch handles all runtime-specific details
+export const handler: AWSLambda.LambdaFunctionURLHandler = handle(server); // That's it — ModelFetch handles all runtime-specific details
 ```
 
 ```typescript title="app/[[...path]]/route.ts" tab="Vercel"

--- a/apps/modelfetch-website/mdx/runtime/aws-lambda.mdx
+++ b/apps/modelfetch-website/mdx/runtime/aws-lambda.mdx
@@ -17,14 +17,14 @@ npm install @modelfetch/aws-lambda
 import handle from "@modelfetch/aws-lambda";
 import server from "./server"; // Import your McpServer
 
-// Export as an AWS Lambda handler
-export const handler: AWSLambda.Handler = handle(server);
+// Export as an AWS Lambda streaming handler
+export const handler: AWSLambda.LambdaFunctionURLHandler = handle(server);
 ```
 
 ## API Reference
 
 ### `handle(server)`
 
-Creates an AWS Lambda handler from an [`McpServer`](https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#server) instance
+Creates an AWS Lambda streaming handler from an [`McpServer`](https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#server) instance
 
 - **server**: Required [`McpServer`](https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#server) instance from [`@modelcontextprotocol/sdk`](https://github.com/modelcontextprotocol/typescript-sdk)

--- a/libs/create-modelfetch/templates/aws-lambda-js/cdk.js.template
+++ b/libs/create-modelfetch/templates/aws-lambda-js/cdk.js.template
@@ -1,5 +1,5 @@
-import { App, CfnOutput, Stack } from "aws-cdk-lib";
-import { FunctionUrlAuthType, Runtime } from "aws-cdk-lib/aws-lambda";
+import { App, CfnOutput, Duration, Stack } from "aws-cdk-lib";
+import { FunctionUrlAuthType, InvokeMode, Runtime } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 
 class <%= awsCdkStack %> extends Stack {
@@ -9,10 +9,12 @@ class <%= awsCdkStack %> extends Stack {
     const nodejsFunction = new NodejsFunction(this, "NodejsFunction", {
       entry: "./src/index.js",
       runtime: Runtime.NODEJS_22_X,
+      timeout: Duration.minutes(5),
     });
 
     const functionUrl = nodejsFunction.addFunctionUrl({
       authType: FunctionUrlAuthType.NONE,
+      invokeMode: InvokeMode.RESPONSE_STREAM,
     });
 
     new CfnOutput(this, "McpServerUrl", { value: `${functionUrl.url}mcp` });

--- a/libs/create-modelfetch/templates/aws-lambda-ts/cdk.js.template
+++ b/libs/create-modelfetch/templates/aws-lambda-ts/cdk.js.template
@@ -1,5 +1,5 @@
-import { App, CfnOutput, Stack } from "aws-cdk-lib";
-import { FunctionUrlAuthType, Runtime } from "aws-cdk-lib/aws-lambda";
+import { App, CfnOutput, Duration, Stack } from "aws-cdk-lib";
+import { FunctionUrlAuthType, InvokeMode, Runtime } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 
 class <%= awsCdkStack %> extends Stack {
@@ -9,10 +9,12 @@ class <%= awsCdkStack %> extends Stack {
     const nodejsFunction = new NodejsFunction(this, "NodejsFunction", {
       entry: "./src/index.ts",
       runtime: Runtime.NODEJS_22_X,
+      timeout: Duration.minutes(5),
     });
 
     const functionUrl = nodejsFunction.addFunctionUrl({
       authType: FunctionUrlAuthType.NONE,
+      invokeMode: InvokeMode.RESPONSE_STREAM,
     });
 
     new CfnOutput(this, "McpServerUrl", { value: `${functionUrl.url}mcp` });

--- a/libs/create-modelfetch/templates/aws-lambda-ts/src/index.ts.template
+++ b/libs/create-modelfetch/templates/aws-lambda-ts/src/index.ts.template
@@ -2,4 +2,4 @@ import handle from "@modelfetch/aws-lambda";
 
 import server from "./server";
 
-export const handler: AWSLambda.Handler = handle(server);
+export const handler: AWSLambda.LambdaFunctionURLHandler = handle(server);

--- a/libs/modelfetch-aws-lambda/README.md
+++ b/libs/modelfetch-aws-lambda/README.md
@@ -18,14 +18,14 @@ npm install @modelfetch/aws-lambda
 import handle from "@modelfetch/aws-lambda";
 import server from "./server"; // Import your McpServer
 
-// Export as an AWS Lambda handler
-export const handler: AWSLambda.Handler = handle(server);
+// Export as an AWS Lambda streaming handler
+export const handler: AWSLambda.LambdaFunctionURLHandler = handle(server);
 ```
 
 ## API Reference
 
 ### `handle(server)`
 
-Creates an AWS Lambda handler from an [`McpServer`](https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#server) instance
+Creates an AWS Lambda streaming handler from an [`McpServer`](https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#server) instance
 
 - **server**: Required [`McpServer`](https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#server) instance from [`@modelcontextprotocol/sdk`](https://github.com/modelcontextprotocol/typescript-sdk)

--- a/libs/modelfetch-aws-lambda/src/index.ts
+++ b/libs/modelfetch-aws-lambda/src/index.ts
@@ -1,11 +1,11 @@
 import type { ServerOrConfig } from "@modelfetch/core";
 
 import { createApp } from "@modelfetch/core";
-import { handle as handler } from "hono/aws-lambda";
+import { streamHandle } from "hono/aws-lambda";
 
 export default function handle(
   arg: ServerOrConfig,
-): ReturnType<typeof handler> {
+): ReturnType<typeof streamHandle> {
   const app = createApp(arg);
-  return handler(app);
+  return streamHandle(app);
 }


### PR DESCRIPTION
## Summary
- Enable AWS Lambda streaming mode with response streaming support
- Update CDK configurations to include 5-minute timeout and `InvokeMode.RESPONSE_STREAM`
- Change TypeScript handler type from `AWSLambda.Handler` to `AWSLambda.LambdaFunctionURLHandler`

## Changes
- Updated example applications (both JS and TS) with streaming configuration
- Updated create-modelfetch templates to match the streaming implementation
- Updated all documentation references to use "AWS Lambda streaming handler"
- Updated TypeScript types across documentation and examples

## Test plan
- [x] Verify AWS Lambda examples deploy successfully with streaming enabled
- [x] Verify create-modelfetch generates correct templates for AWS Lambda
- [x] Check documentation renders correctly on the website

🤖 Generated with [Claude Code](https://claude.ai/code)