### PR TITLE
Remove AWS Lambda streaming mode support

### DIFF
--- a/.nx/version-plans/remove-aws-lambda-streaming.md
+++ b/.nx/version-plans/remove-aws-lambda-streaming.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Remove AWS Lambda streaming mode support due to compatibility issues

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ handle(server); // That's it — ModelFetch handles all runtime-specific details
 import handle from "@modelfetch/aws-lambda"; // Choose your runtime
 import server from "./server"; // Import your server
 
-export const handler: AWSLambda.LambdaFunctionURLHandler = handle(server); // That's it — ModelFetch handles all runtime-specific details
+export const handler: AWSLambda.Handler = handle(server); // That's it — ModelFetch handles all runtime-specific details
 ```
 
 #### Vercel

--- a/apps/example-aws-lambda-js/cdk.js
+++ b/apps/example-aws-lambda-js/cdk.js
@@ -1,9 +1,5 @@
 import { App, CfnOutput, Duration, Stack } from "aws-cdk-lib";
-import {
-  FunctionUrlAuthType,
-  InvokeMode,
-  Runtime,
-} from "aws-cdk-lib/aws-lambda";
+import { FunctionUrlAuthType, Runtime } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 
 class ModelFetchExampleAWSLambdaJavaScriptStack extends Stack {
@@ -18,7 +14,6 @@ class ModelFetchExampleAWSLambdaJavaScriptStack extends Stack {
 
     const functionUrl = nodejsFunction.addFunctionUrl({
       authType: FunctionUrlAuthType.NONE,
-      invokeMode: InvokeMode.RESPONSE_STREAM,
     });
 
     new CfnOutput(this, "McpServerUrl", { value: `${functionUrl.url}mcp` });

--- a/apps/example-aws-lambda-ts/cdk.js
+++ b/apps/example-aws-lambda-ts/cdk.js
@@ -1,9 +1,5 @@
 import { App, CfnOutput, Duration, Stack } from "aws-cdk-lib";
-import {
-  FunctionUrlAuthType,
-  InvokeMode,
-  Runtime,
-} from "aws-cdk-lib/aws-lambda";
+import { FunctionUrlAuthType, Runtime } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 
 class ModelFetchExampleAWSLambdaTypeScriptStack extends Stack {
@@ -18,7 +14,6 @@ class ModelFetchExampleAWSLambdaTypeScriptStack extends Stack {
 
     const functionUrl = nodejsFunction.addFunctionUrl({
       authType: FunctionUrlAuthType.NONE,
-      invokeMode: InvokeMode.RESPONSE_STREAM,
     });
 
     new CfnOutput(this, "McpServerUrl", { value: `${functionUrl.url}mcp` });

--- a/apps/example-aws-lambda-ts/src/index.ts
+++ b/apps/example-aws-lambda-ts/src/index.ts
@@ -2,4 +2,4 @@ import handle from "@modelfetch/aws-lambda";
 
 import server from "./server";
 
-export const handler: AWSLambda.LambdaFunctionURLHandler = handle(server);
+export const handler: AWSLambda.Handler = handle(server);

--- a/apps/modelfetch-website/lib/runtime-selector/index.tsx
+++ b/apps/modelfetch-website/lib/runtime-selector/index.tsx
@@ -67,7 +67,7 @@ handle(server);`,
     codeExample: `import handle from "@modelfetch/aws-lambda";
 import server from "./server";
 
-export const handler: AWSLambda.LambdaFunctionURLHandler = handle(server);`,
+export const handler: AWSLambda.Handler = handle(server);`,
   },
   {
     id: "vercel",

--- a/apps/modelfetch-website/mdx/index.mdx
+++ b/apps/modelfetch-website/mdx/index.mdx
@@ -86,7 +86,7 @@ handle(server); // That's it — ModelFetch handles all runtime-specific details
 import handle from "@modelfetch/aws-lambda"; // Choose your runtime
 import server from "./server"; // Import your server
 
-export const handler: AWSLambda.LambdaFunctionURLHandler = handle(server); // That's it — ModelFetch handles all runtime-specific details
+export const handler: AWSLambda.Handler = handle(server); // That's it — ModelFetch handles all runtime-specific details
 ```
 
 ```typescript title="app/[[...path]]/route.ts" tab="Vercel"
@@ -162,7 +162,7 @@ handle(server); // That's it — ModelFetch handles all runtime-specific details
 import handle from "@modelfetch/aws-lambda"; // Choose your runtime
 import server from "./server"; // Import your server
 
-export const handler: AWSLambda.LambdaFunctionURLHandler = handle(server); // That's it — ModelFetch handles all runtime-specific details
+export const handler: AWSLambda.Handler = handle(server); // That's it — ModelFetch handles all runtime-specific details
 ```
 
 ```typescript title="app/[[...path]]/route.ts" tab="Vercel"

--- a/apps/modelfetch-website/mdx/quick-start.mdx
+++ b/apps/modelfetch-website/mdx/quick-start.mdx
@@ -129,7 +129,7 @@ handle(server); // That's it — ModelFetch handles all runtime-specific details
 import handle from "@modelfetch/aws-lambda"; // Choose your runtime
 import server from "./server"; // Import your server
 
-export const handler: AWSLambda.LambdaFunctionURLHandler = handle(server); // That's it — ModelFetch handles all runtime-specific details
+export const handler: AWSLambda.Handler = handle(server); // That's it — ModelFetch handles all runtime-specific details
 ```
 
 ```typescript title="app/[[...path]]/route.ts" tab="Vercel"

--- a/apps/modelfetch-website/mdx/runtime/aws-lambda.mdx
+++ b/apps/modelfetch-website/mdx/runtime/aws-lambda.mdx
@@ -17,14 +17,14 @@ npm install @modelfetch/aws-lambda
 import handle from "@modelfetch/aws-lambda";
 import server from "./server"; // Import your McpServer
 
-// Export as an AWS Lambda streaming handler
-export const handler: AWSLambda.LambdaFunctionURLHandler = handle(server);
+// Export as an AWS Lambda handler
+export const handler: AWSLambda.Handler = handle(server);
 ```
 
 ## API Reference
 
 ### `handle(server)`
 
-Creates an AWS Lambda streaming handler from an [`McpServer`](https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#server) instance
+Creates an AWS Lambda handler from an [`McpServer`](https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#server) instance
 
 - **server**: Required [`McpServer`](https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#server) instance from [`@modelcontextprotocol/sdk`](https://github.com/modelcontextprotocol/typescript-sdk)

--- a/libs/create-modelfetch/templates/aws-lambda-js/cdk.js.template
+++ b/libs/create-modelfetch/templates/aws-lambda-js/cdk.js.template
@@ -1,5 +1,5 @@
 import { App, CfnOutput, Duration, Stack } from "aws-cdk-lib";
-import { FunctionUrlAuthType, InvokeMode, Runtime } from "aws-cdk-lib/aws-lambda";
+import { FunctionUrlAuthType, Runtime } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 
 class <%= awsCdkStack %> extends Stack {
@@ -14,7 +14,6 @@ class <%= awsCdkStack %> extends Stack {
 
     const functionUrl = nodejsFunction.addFunctionUrl({
       authType: FunctionUrlAuthType.NONE,
-      invokeMode: InvokeMode.RESPONSE_STREAM,
     });
 
     new CfnOutput(this, "McpServerUrl", { value: `${functionUrl.url}mcp` });

--- a/libs/create-modelfetch/templates/aws-lambda-ts/cdk.js.template
+++ b/libs/create-modelfetch/templates/aws-lambda-ts/cdk.js.template
@@ -1,5 +1,5 @@
 import { App, CfnOutput, Duration, Stack } from "aws-cdk-lib";
-import { FunctionUrlAuthType, InvokeMode, Runtime } from "aws-cdk-lib/aws-lambda";
+import { FunctionUrlAuthType, Runtime } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 
 class <%= awsCdkStack %> extends Stack {
@@ -14,7 +14,6 @@ class <%= awsCdkStack %> extends Stack {
 
     const functionUrl = nodejsFunction.addFunctionUrl({
       authType: FunctionUrlAuthType.NONE,
-      invokeMode: InvokeMode.RESPONSE_STREAM,
     });
 
     new CfnOutput(this, "McpServerUrl", { value: `${functionUrl.url}mcp` });

--- a/libs/create-modelfetch/templates/aws-lambda-ts/src/index.ts.template
+++ b/libs/create-modelfetch/templates/aws-lambda-ts/src/index.ts.template
@@ -2,4 +2,4 @@ import handle from "@modelfetch/aws-lambda";
 
 import server from "./server";
 
-export const handler: AWSLambda.LambdaFunctionURLHandler = handle(server);
+export const handler: AWSLambda.Handler = handle(server);

--- a/libs/modelfetch-aws-lambda/README.md
+++ b/libs/modelfetch-aws-lambda/README.md
@@ -18,14 +18,14 @@ npm install @modelfetch/aws-lambda
 import handle from "@modelfetch/aws-lambda";
 import server from "./server"; // Import your McpServer
 
-// Export as an AWS Lambda streaming handler
-export const handler: AWSLambda.LambdaFunctionURLHandler = handle(server);
+// Export as an AWS Lambda handler
+export const handler: AWSLambda.Handler = handle(server);
 ```
 
 ## API Reference
 
 ### `handle(server)`
 
-Creates an AWS Lambda streaming handler from an [`McpServer`](https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#server) instance
+Creates an AWS Lambda handler from an [`McpServer`](https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#server) instance
 
 - **server**: Required [`McpServer`](https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#server) instance from [`@modelcontextprotocol/sdk`](https://github.com/modelcontextprotocol/typescript-sdk)

--- a/libs/modelfetch-aws-lambda/src/index.ts
+++ b/libs/modelfetch-aws-lambda/src/index.ts
@@ -1,11 +1,11 @@
 import type { ServerOrConfig } from "@modelfetch/core";
 
 import { createApp } from "@modelfetch/core";
-import { streamHandle } from "hono/aws-lambda";
+import { handle as handler } from "hono/aws-lambda";
 
 export default function handle(
   arg: ServerOrConfig,
-): ReturnType<typeof streamHandle> {
+): ReturnType<typeof handler> {
   const app = createApp(arg);
-  return streamHandle(app);
+  return handler(app);
 }


### PR DESCRIPTION
## Summary
- Reverted AWS Lambda integration from streaming mode back to standard buffered responses
- Updated all templates, documentation, and examples to use standard `Handler` type instead of `LambdaFunctionURLHandler`
- Removed `InvokeMode.RESPONSE_STREAM` configuration from CDK templates

## Why this change?
The streaming mode implementation was causing compatibility issues that prevented AWS Lambda functions from executing properly. This change ensures reliable AWS Lambda deployments while maintaining full MCP server functionality.

## Changes made
- Removed streaming mode configuration from CDK templates
- Changed handler type from `LambdaFunctionURLHandler` to `Handler`
- Updated core library to use standard `handle` instead of `streamHandle`
- Updated all documentation and examples to reflect non-streaming mode

## Test plan
- [x] Build and deploy AWS Lambda examples
- [x] Verify MCP server responds correctly without streaming
- [x] Test with MCP clients to ensure compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)