### PR TITLE
Update JSR configuration and simplify release executor

### DIFF
--- a/.nx/version-plans/update-jsr-configuration.md
+++ b/.nx/version-plans/update-jsr-configuration.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Update JSR configuration for modelfetch-core and simplify prepare-release-publish executor

--- a/libs/modelfetch-core/jsr.json
+++ b/libs/modelfetch-core/jsr.json
@@ -1,1 +1,4 @@
-{}
+{
+  "exports": "./src/index.ts",
+  "publish": { "include": ["src"] }
+}

--- a/libs/nx-10x/src/executors/prepare-release-publish/index.ts
+++ b/libs/nx-10x/src/executors/prepare-release-publish/index.ts
@@ -20,7 +20,6 @@ export default async function prepareReleasePublish(
   if (!context.projectName) return { success: false };
   const project = context.projectsConfigurations.projects[context.projectName];
   const packageJsonPath = path.join(context.root, project.root, "package.json");
-  const jsrJsonPath = path.join(context.root, project.root, "jsr.json");
   const packageJson = JSON.parse(
     await readFile(packageJsonPath, "utf8"),
   ) as PackageJson;
@@ -39,15 +38,12 @@ export default async function prepareReleasePublish(
     }
   }
   await writeFile(packageJsonPath, JSON.stringify(packageJson));
+  const jsrJsonPath = path.join(context.root, project.root, "jsr.json");
   if (existsSync(jsrJsonPath)) {
     const jsrJson = JSON.parse(await readFile(jsrJsonPath, "utf8")) as JsrJson;
     jsrJson.name = packageJson.name;
     jsrJson.version = packageJson.version;
     jsrJson.license = packageJson.license;
-    if (!jsrJson.exports && !jsrJson.publish) {
-      jsrJson.exports = packageJson.exports;
-      jsrJson.publish = { include: packageJson.files };
-    }
     await writeFile(jsrJsonPath, JSON.stringify(jsrJson));
   }
   return { success: true };


### PR DESCRIPTION
## Summary
- Add explicit exports and publish configuration to modelfetch-core JSR config
- Remove automatic JSR configuration logic from prepare-release-publish executor
- Simplify executor to only update name, version, and license fields

## Test plan
- [ ] Verify that JSR configuration is correctly formatted
- [ ] Ensure prepare-release-publish executor works correctly with the simplified logic
- [ ] Confirm that release process continues to function as expected

🤖 Generated with [Claude Code](https://claude.ai/code)