### PR TITLE
Add JSR support for modelfetch-netlify and enhance release executor

### DIFF
--- a/.nx/version-plans/add-netlify-jsr-publishing.md
+++ b/.nx/version-plans/add-netlify-jsr-publishing.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Add JSR publishing support for @modelfetch/netlify and fix workspace dependency resolution in release executor

--- a/libs/modelfetch-netlify/jsr.json
+++ b/libs/modelfetch-netlify/jsr.json
@@ -1,0 +1,4 @@
+{
+  "exports": "./src/index.ts",
+  "publish": { "include": ["src", "LICENSE", "README.md"] }
+}

--- a/libs/nx-10x/src/executors/prepare-release-publish/index.ts
+++ b/libs/nx-10x/src/executors/prepare-release-publish/index.ts
@@ -5,6 +5,8 @@ import { existsSync } from "node:fs";
 import { copyFile, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
+const workspaceVersionProtocol = "workspace:";
+
 interface JsrJson
   extends Pick<PackageJson, "name" | "version" | "license" | "exports"> {
   publish?: {
@@ -24,8 +26,67 @@ export default async function prepareReleasePublish(
     await readFile(packageJsonPath, "utf8"),
   ) as PackageJson;
   if (packageJson.private) return { success: false };
-  for (const key of ["scripts", "devDependencies"])
+  for (const key of [
+    "scripts",
+    "devDependencies",
+    "bundleDependencies",
+    "bundledDependencies",
+  ])
     if (key in packageJson) delete packageJson[key];
+  for (const depType of [
+    "dependencies",
+    "peerDependencies",
+    "optionalDependencies",
+  ] as const) {
+    const deps = packageJson[depType];
+    if (deps) {
+      for (const [depName, depVersion] of Object.entries(deps)) {
+        if (
+          depVersion?.startsWith("workspace:") &&
+          depName in context.projectsConfigurations.projects
+        ) {
+          const depProject = context.projectsConfigurations.projects[depName];
+          const depPackageJsonPath = path.join(
+            context.root,
+            depProject.root,
+            "package.json",
+          );
+          if (existsSync(depPackageJsonPath)) {
+            const depPackageJson = JSON.parse(
+              await readFile(depPackageJsonPath, "utf8"),
+            ) as PackageJson;
+            if (depPackageJson.version) {
+              const workspaceVersionRange = depVersion.slice(
+                workspaceVersionProtocol.length,
+              );
+              switch (workspaceVersionRange) {
+                case "*": {
+                  // workspace:* -> exact version
+                  deps[depName] = depPackageJson.version;
+                  break;
+                }
+                case "~": {
+                  // workspace:~ -> ~version
+                  deps[depName] = `~${depPackageJson.version}`;
+                  break;
+                }
+                case "^": {
+                  // workspace:^ -> ^version
+                  deps[depName] = `^${depPackageJson.version}`;
+                  break;
+                }
+                default: {
+                  // workspace:^1.5.0 -> use the range as-is
+                  deps[depName] = workspaceVersionRange;
+                  break;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
   const exportEntries = [packageJson.exports];
   while (exportEntries.length > 0) {
     const exportEntry = exportEntries.pop();

--- a/libs/nx-10x/src/executors/prepare-release-publish/index.ts
+++ b/libs/nx-10x/src/executors/prepare-release-publish/index.ts
@@ -42,8 +42,8 @@ export default async function prepareReleasePublish(
     if (deps) {
       for (const [depName, depVersion] of Object.entries(deps)) {
         if (
-          depVersion?.startsWith(workspaceVersionProtocol) &&
-          depName in context.projectsConfigurations.projects
+          depName in context.projectsConfigurations.projects &&
+          depVersion?.startsWith(workspaceVersionProtocol)
         ) {
           const depProject = context.projectsConfigurations.projects[depName];
           const depPackageJsonPath = path.join(

--- a/libs/nx-10x/src/executors/prepare-release-publish/index.ts
+++ b/libs/nx-10x/src/executors/prepare-release-publish/index.ts
@@ -42,7 +42,7 @@ export default async function prepareReleasePublish(
     if (deps) {
       for (const [depName, depVersion] of Object.entries(deps)) {
         if (
-          depVersion?.startsWith("workspace:") &&
+          depVersion?.startsWith(workspaceVersionProtocol) &&
           depName in context.projectsConfigurations.projects
         ) {
           const depProject = context.projectsConfigurations.projects[depName];


### PR DESCRIPTION
## Summary
- Add JSR (JavaScript Registry) configuration for @modelfetch/netlify package
- Enhance the release publish executor to properly resolve workspace protocol dependencies
- Enable JSR publishing workflow for the Netlify runtime package

## Test plan
- [ ] Verify JSR configuration is valid for @modelfetch/netlify
- [ ] Test that workspace dependencies are correctly resolved during release
- [ ] Confirm existing npm publishing continues to work
- [ ] Validate that the release executor handles all workspace protocol formats

🤖 Generated with [Claude Code](https://claude.ai/code)