### PR TITLE
Optimize build performance and improve JSR publishing

### DIFF
--- a/.nx/version-plans/build-and-release-optimizations.md
+++ b/.nx/version-plans/build-and-release-optimizations.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Optimize build performance in CI and improve JSR publishing with --no-check flag

--- a/apps/modelfetch-website/next.config.js
+++ b/apps/modelfetch-website/next.config.js
@@ -1,15 +1,20 @@
 import { createMDX } from "fumadocs-mdx/next";
 
-export default createMDX()({
+/** @type {import('next').NextConfig} */
+const nextConfig = {
   eslint: { ignoreDuringBuilds: true },
   typescript: { ignoreBuildErrors: true },
-  webpack: process.env.GITHUB_ACTIONS
-    ? (config) => {
-        if (config.cache) config.cache = Object.freeze({ type: "memory" });
-        return config;
-      }
-    : undefined,
-  experimental: process.env.GITHUB_ACTIONS
-    ? { webpackMemoryOptimizations: true, webpackBuildWorker: true }
-    : undefined,
-});
+};
+
+if (process.env.GITHUB_ACTIONS === "true") {
+  nextConfig.webpack = (config) => {
+    if (config.cache) config.cache = Object.freeze({ type: "memory" });
+    return config;
+  };
+  nextConfig.experimental = {
+    webpackMemoryOptimizations: true,
+    webpackBuildWorker: true,
+  };
+}
+
+export default createMDX()(nextConfig);

--- a/apps/modelfetch-website/next.config.js
+++ b/apps/modelfetch-website/next.config.js
@@ -3,4 +3,13 @@ import { createMDX } from "fumadocs-mdx/next";
 export default createMDX()({
   eslint: { ignoreDuringBuilds: true },
   typescript: { ignoreBuildErrors: true },
+  webpack: process.env.GITHUB_ACTIONS
+    ? (config) => {
+        if (config.cache) config.cache = Object.freeze({ type: "memory" });
+        return config;
+      }
+    : undefined,
+  experimental: process.env.GITHUB_ACTIONS
+    ? { webpackMemoryOptimizations: true, webpackBuildWorker: true }
+    : undefined,
 });

--- a/libs/nx-10x/src/index.ts
+++ b/libs/nx-10x/src/index.ts
@@ -124,10 +124,7 @@ export const createNodesV2: CreateNodesV2 = [
             targets.build = {
               cache: true,
               command: "next build",
-              options: {
-                cwd: "{projectRoot}",
-                env: { NODE_OPTIONS: "--max_old_space_size=4096" },
-              },
+              options: { cwd: "{projectRoot}" },
               inputs: [
                 "production",
                 "^production",
@@ -248,7 +245,8 @@ export const createNodesV2: CreateNodesV2 = [
             fs.existsSync(path.join(projectRoot, "deno.jsonc"))
           ) {
             targets["jsr-release-publish"] = {
-              command: "deno publish --allow-dirty --allow-slow-types",
+              command:
+                "deno publish --no-check --allow-dirty --allow-slow-types",
               options: { cwd: "{projectRoot}" },
             };
           }


### PR DESCRIPTION
## Summary
- Add webpack memory optimizations for CI builds to reduce memory usage and improve performance
- Remove unnecessary NODE_OPTIONS memory limit from Next.js builds
- Add --no-check flag to deno publish for faster JSR releases

## Test plan
- [x] All type checks pass (`pnpm exec nx run-many -t typecheck`)
- [x] All linting passes (`pnpm exec nx run-many -t lint`)
- [x] Version plan created for patch release
- [ ] CI builds complete successfully with the new optimizations
- [ ] JSR publishing works correctly with the --no-check flag

🤖 Generated with [Claude Code](https://claude.ai/code)