### PR TITLE
Update Deno configuration from jsr.json to deno.json

### DIFF
--- a/.nx/version-plans/update-deno-configuration.md
+++ b/.nx/version-plans/update-deno-configuration.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Update Deno configuration from jsr.json to deno.json and simplify JSR publishing logic

--- a/libs/modelfetch-core/deno.json
+++ b/libs/modelfetch-core/deno.json
@@ -1,0 +1,4 @@
+{
+  "publish": { "include": ["src", "LICENSE", "README.md"] },
+  "exports": "./src/index.ts"
+}

--- a/libs/modelfetch-core/jsr.json
+++ b/libs/modelfetch-core/jsr.json
@@ -1,4 +1,0 @@
-{
-  "exports": "./src/index.ts",
-  "publish": { "include": ["src", "LICENSE", "README.md"] }
-}

--- a/libs/modelfetch-deno/deno.json
+++ b/libs/modelfetch-deno/deno.json
@@ -1,0 +1,4 @@
+{
+  "publish": { "include": ["src", "LICENSE", "README.md"] },
+  "exports": "./src/index.ts"
+}

--- a/libs/modelfetch-deno/jsr.json
+++ b/libs/modelfetch-deno/jsr.json
@@ -1,4 +1,0 @@
-{
-  "exports": "./src/index.ts",
-  "publish": { "include": ["src", "LICENSE", "README.md"] }
-}

--- a/libs/modelfetch-netlify/deno.json
+++ b/libs/modelfetch-netlify/deno.json
@@ -1,0 +1,4 @@
+{
+  "publish": { "include": ["src", "LICENSE", "README.md"] },
+  "exports": "./src/index.ts"
+}

--- a/libs/modelfetch-netlify/jsr.json
+++ b/libs/modelfetch-netlify/jsr.json
@@ -1,4 +1,0 @@
-{
-  "exports": "./src/index.ts",
-  "publish": { "include": ["src", "LICENSE", "README.md"] }
-}

--- a/libs/nx-10x/src/index.ts
+++ b/libs/nx-10x/src/index.ts
@@ -50,10 +50,7 @@ function getDefaultStartCommand(
     entryPoint.endsWith(".cjs") ||
     entryPoint.endsWith(".mjs");
   if (!isTypeScript && !isJavaScript) return;
-  if (
-    fs.existsSync(path.join(projectRoot, "deno.json")) ||
-    fs.existsSync(path.join(projectRoot, "deno.jsonc"))
-  )
+  if (fs.existsSync(path.join(projectRoot, "deno.json")))
     return `deno run -A ${entryPoint}`;
   if (fs.existsSync(path.join(projectRoot, "bunfig.toml"))) return "bun .";
   if (packageJson.dependencies?.tsx || packageJson.devDependencies?.tsx)
@@ -243,17 +240,12 @@ export const createNodesV2: CreateNodesV2 = [
           targets["prepare-release-publish"] = {
             executor: "nx-10x:prepare-release-publish",
           };
-          if (
-            fs.existsSync(path.join(projectRoot, "jsr.json")) ||
-            fs.existsSync(path.join(projectRoot, "deno.json")) ||
-            fs.existsSync(path.join(projectRoot, "deno.jsonc"))
-          ) {
+          if (fs.existsSync(path.join(projectRoot, "deno.json"))) {
             targets["jsr-release-publish"] = {
               command:
                 "deno publish --no-check --allow-dirty --allow-slow-types",
               options: { cwd: "{projectRoot}" },
             };
-            tags.push("jsr");
           }
         }
         return { projects: { [projectRoot]: { projectType, targets, tags } } };


### PR DESCRIPTION
## Summary
- Renamed `jsr.json` files to `deno.json` across modelfetch packages
- Updated nx-10x executor to handle the new deno.json structure
- Removed the "jsr" tag system for simpler JSR publishing detection

## Test plan
- [ ] Run `pnpm exec nx run-many -t typecheck` to verify TypeScript compilation
- [ ] Run `pnpm exec nx run-many -t lint` to ensure code quality
- [ ] Run `pnpm exec nx run-many -t build` to verify builds succeed
- [ ] Test JSR publishing with `pnpm exec nx run <package>:jsr-release-publish --dry-run`

🤖 Generated with [Claude Code](https://claude.ai/code)