### PR TITLE
Improve JSR publishing configuration

### DIFF
--- a/.nx/version-plans/improve-jsr-publishing.md
+++ b/.nx/version-plans/improve-jsr-publishing.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Improve JSR publishing by adding nodeModulesDir configuration and proper task dependencies

--- a/libs/nx-10x/src/executors/prepare-release-publish/index.ts
+++ b/libs/nx-10x/src/executors/prepare-release-publish/index.ts
@@ -10,7 +10,7 @@ const workspaceVersionProtocol = "workspace:";
 interface DenoJson
   extends Pick<PackageJson, "name" | "version" | "license" | "exports"> {
   imports?: Record<string, string>;
-  publish?: { include?: string[]; exclude?: string[] };
+  nodeModulesDir?: "none" | "auto" | "manual";
 }
 
 export default async function prepareReleasePublish(
@@ -112,6 +112,7 @@ export default async function prepareReleasePublish(
       await readFile(denoJsonPath, "utf8"),
     ) as DenoJson;
     denoJson.imports = denoImports;
+    denoJson.nodeModulesDir = "none";
     denoJson.name = packageJson.name;
     denoJson.version = packageJson.version;
     denoJson.license = packageJson.license;

--- a/libs/nx-10x/src/index.ts
+++ b/libs/nx-10x/src/index.ts
@@ -245,6 +245,7 @@ export const createNodesV2: CreateNodesV2 = [
               command:
                 "deno publish --no-check --allow-dirty --allow-slow-types",
               options: { cwd: "{projectRoot}" },
+              dependsOn: ["^jsr-release-publish"],
             };
           }
         }


### PR DESCRIPTION
## Summary
- Added `nodeModulesDir: "none"` to deno.json during JSR publishing to prevent node_modules generation
- Added `dependsOn: ["^jsr-release-publish"]` to ensure parent projects are published before dependent projects
- These changes improve the JSR publishing process reliability and prevent unnecessary file generation

## Test plan
- [ ] Run `pnpm exec nx run-many -t jsr-release-publish` to verify JSR publishing works correctly
- [ ] Verify that no node_modules directories are created during JSR publishing
- [ ] Confirm that parent projects are published before their dependents

🤖 Generated with [Claude Code](https://claude.ai/code)