### PR TITLE
Add gitignore templates and fix deploy command for Fastly templates

### DIFF
--- a/.nx/version-plans/fix-fastly-templates.md
+++ b/.nx/version-plans/fix-fastly-templates.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Add gitignore templates and fix deploy command for Fastly templates

--- a/libs/create-modelfetch/templates/fastly-js/.gitignore.template
+++ b/libs/create-modelfetch/templates/fastly-js/.gitignore.template
@@ -1,0 +1,4 @@
+.DS_Store
+node_modules
+bin
+pkg

--- a/libs/create-modelfetch/templates/fastly-js/package.json.template
+++ b/libs/create-modelfetch/templates/fastly-js/package.json.template
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "start": "fastly compute serve",
-    "deploy": "fastly compute deploy"
+    "deploy": "fastly compute publish"
   },
   "dependencies": {
     "@fastly/js-compute": "<%= versions['@fastly/js-compute'] %>",

--- a/libs/create-modelfetch/templates/fastly-ts/.gitignore.template
+++ b/libs/create-modelfetch/templates/fastly-ts/.gitignore.template
@@ -1,0 +1,6 @@
+.DS_Store
+node_modules
+bin
+pkg
+*.tsbuildinfo
+dist

--- a/libs/create-modelfetch/templates/fastly-ts/package.json.template
+++ b/libs/create-modelfetch/templates/fastly-ts/package.json.template
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "start": "fastly compute serve",
-    "deploy": "fastly compute deploy"
+    "deploy": "fastly compute publish"
   },
   "dependencies": {
     "@fastly/js-compute": "<%= versions['@fastly/js-compute'] %>",


### PR DESCRIPTION
## Summary
- Add .gitignore templates for both JavaScript and TypeScript Fastly templates
- Fix deploy command from deprecated `fastly compute deploy` to correct `fastly compute publish`
- Include standard ignored files/folders appropriate for Fastly Compute projects

## Details
The Fastly templates were missing .gitignore files which could lead to unwanted files being committed. Additionally, the deploy command was using the deprecated `deploy` subcommand instead of the current `publish` command.

### Files added:
- `libs/create-modelfetch/templates/fastly-js/.gitignore.template`
- `libs/create-modelfetch/templates/fastly-ts/.gitignore.template`

### Changes made:
- Updated deploy script in both package.json templates from `fastly compute deploy` to `fastly compute publish`
- Added appropriate gitignore entries for Fastly Compute projects

## Test plan
- [ ] Run `create-modelfetch` with Fastly JS template and verify .gitignore is created
- [ ] Run `create-modelfetch` with Fastly TS template and verify .gitignore is created
- [ ] Verify `npm run deploy` uses the correct `fastly compute publish` command

🤖 Generated with [Claude Code](https://claude.ai/code)