### PR TITLE
Add Node.js engine requirement to create-modelfetch

### DIFF
--- a/.nx/version-plans/add-node-engine-requirement.md
+++ b/.nx/version-plans/add-node-engine-requirement.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Add Node.js engine requirement (>=20.10) to create-modelfetch package

--- a/libs/create-modelfetch/package.json
+++ b/libs/create-modelfetch/package.json
@@ -55,5 +55,8 @@
     "@types/ejs": "^3.1.5",
     "@types/validate-npm-package-name": "^4.0.2",
     "create-eslint-config": "workspace:^"
+  },
+  "engines": {
+    "node": ">=20.10"
   }
 }


### PR DESCRIPTION
## Summary
- Add Node.js engine requirement (>=20.10) to create-modelfetch package
- This ensures compatibility with required features and dependencies
- Created version plan for patch release

## Test plan
- [x] Run `pnpm -w format` - passes
- [x] Run `pnpm exec nx run-many -t typecheck` - passes
- [x] Run `pnpm exec nx run-many -t lint --args=--fix` - passes
- [ ] Verify create-modelfetch works with Node.js 20.10+
- [ ] Verify create-modelfetch shows appropriate error with older Node.js versions

🤖 Generated with [Claude Code](https://claude.ai/code)