### PR TITLE
Add path configuration option

### DIFF
--- a/.nx/version-plans/add-path-config-option.md
+++ b/.nx/version-plans/add-path-config-option.md
@@ -1,0 +1,5 @@
+---
+__default__: minor
+---
+
+Add path configuration option to customize MCP server endpoint path

--- a/libs/modelfetch-core/src/index.ts
+++ b/libs/modelfetch-core/src/index.ts
@@ -11,6 +11,7 @@ export interface Server {
 
 export interface Config {
   server: Server;
+  path?: string;
   middleware?: MiddlewareHandler[];
   pre?: (app: Hono) => void;
   post?: (app: Hono) => void;
@@ -25,10 +26,11 @@ export function createApp(arg: ServerOrConfig): App {
 
   if (config.pre) config.pre(app);
 
-  if (config.middleware)
-    for (const fn of config.middleware) app.use("/mcp", fn);
+  const path = config.path ?? "/mcp";
 
-  app.all("/mcp", async (c) => {
+  if (config.middleware) for (const fn of config.middleware) app.use(path, fn);
+
+  app.all(path, async (c) => {
     const transport = new StreamableHTTPTransport();
     await config.server.connect(transport);
     return transport.handleRequest(c);


### PR DESCRIPTION
## Summary
- Added `path` configuration option to `@modelfetch/core` to allow customizing the MCP server endpoint path
- Updated route registration to use the configured path instead of hardcoded "/mcp"
- Default path remains "/mcp" for backward compatibility

## Test plan
- [ ] Build and type check pass for all packages
- [ ] All linting checks pass
- [ ] Example applications work correctly with custom paths
- [ ] Default behavior (no path specified) still works as before

🤖 Generated with [Claude Code](https://claude.ai/code)