### PR TITLE
Rename path config to base and update implementation

### DIFF
--- a/.nx/version-plans/add-path-config-option.md
+++ b/.nx/version-plans/add-path-config-option.md
@@ -2,4 +2,4 @@
 __default__: minor
 ---
 
-Add path configuration option to customize MCP server endpoint path
+Add base configuration option to customize MCP server base path


### PR DESCRIPTION
## Summary
- Renamed the `path` configuration option to `base` for better API consistency
- Updated implementation to use Hono's `basePath()` method for cleaner route handling
- This is a breaking change that improves the API design

## Test plan
- [ ] Verify all examples still work with the new `base` configuration
- [ ] Check that the MCP server responds correctly at the configured base path
- [ ] Ensure middleware and pre/post hooks work with the new routing structure

🤖 Generated with [Claude Code](https://claude.ai/code)