### PR TITLE
Add Gcore runtime support

### DIFF
--- a/.nx/version-plans/add-gcore-runtime-support.md
+++ b/.nx/version-plans/add-gcore-runtime-support.md
@@ -1,0 +1,5 @@
+---
+__default__: minor
+---
+
+Add Gcore runtime support with @modelfetch/gcore package, example applications, and deployment executor

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ The SDK is built as a thin wrapper on top of `hono` and `@hono/mcp`, leveraging 
 - `@modelfetch/cloudflare` - Cloudflare runtime support
 - `@modelfetch/netlify` - Netlify runtime support
 - `@modelfetch/fastly` - Fastly runtime support
+- `@modelfetch/gcore` - Gcore runtime support
 - `@modelfetch/aws-lambda` - AWS Lambda runtime support
 - `@modelfetch/azure-functions` - Azure Functions runtime support
 
@@ -69,6 +70,8 @@ These projects are example applications powered by ModelFetch:
 - `example-netlify-ts`: Netlify application (TypeScript)
 - `example-fastly-js`: Fastly application (JavaScript)
 - `example-fastly-ts`: Fastly application (TypeScript)
+- `example-gcore-js`: Gcore application (JavaScript)
+- `example-gcore-ts`: Gcore application (TypeScript)
 - `example-aws-lambda-js`: AWS Lambda application (JavaScript)
 - `example-aws-lambda-ts`: AWS Lambda application (TypeScript)
 - `example-azure-functions-js`: Azure Functions application (JavaScript)
@@ -86,6 +89,7 @@ These projects are example applications powered by ModelFetch:
 - `@modelfetch/cloudflare`: Cloudflare runtime support
 - `@modelfetch/netlify`: Netlify runtime support
 - `@modelfetch/fastly`: Fastly runtime support
+- `@modelfetch/gcore`: Gcore runtime support
 - `@modelfetch/aws-lambda`: AWS Lambda runtime support
 - `@modelfetch/azure-functions`: Azure Functions runtime support
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## 🚀 Features
 
-- **Multi-Runtime**: Write once, run anywhere: Node.js, Next.js, Bun, Deno, Vercel, Cloudflare, Netlify, Fastly, AWS Lambda, and Azure Functions
+- **Multi-Runtime**: Write once, run anywhere: Node.js, Next.js, Bun, Deno, Vercel, Cloudflare, Netlify, Fastly, Gcore, AWS Lambda, and Azure Functions
 - **Official SDK**: Built on top of the [official MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk) to avoid lock-in, guarantee long-term support, and ensure up-to-date implementation
 - **Live Reload**: Development server with automatic reloading
 - **MCP Inspector**: Built-in integration for testing and debugging
@@ -152,6 +152,15 @@ import server from "./server"; // Import your server
 handle(server); // That's it — ModelFetch handles all runtime-specific details
 ```
 
+#### Gcore
+
+```typescript
+import handle from "@modelfetch/gcore"; // Choose your runtime
+import server from "./server"; // Import your server
+
+handle(server); // That's it — ModelFetch handles all runtime-specific details
+```
+
 #### AWS Lambda
 
 ```typescript
@@ -197,6 +206,7 @@ ModelFetch provides runtime-specific packages that handle tedious platform diffe
 | [`@modelfetch/cloudflare`](libs/modelfetch-cloudflare)           | Deploy MCP servers to Cloudflare        | ✅ Ready |
 | [`@modelfetch/netlify`](libs/modelfetch-netlify)                 | Deploy MCP servers to Netlify           | ✅ Ready |
 | [`@modelfetch/fastly`](libs/modelfetch-fastly)                   | Deploy MCP servers to Fastly            | ✅ Ready |
+| [`@modelfetch/gcore`](libs/modelfetch-gcore)                     | Deploy MCP servers to Gcore             | ✅ Ready |
 | [`@modelfetch/aws-lambda`](libs/modelfetch-aws-lambda)           | Deploy MCP servers to AWS Lambda        | ✅ Ready |
 | [`@modelfetch/azure-functions`](libs/modelfetch-azure-functions) | Deploy MCP servers to Azure Functions   | ✅ Ready |
 

--- a/apps/example-gcore-js/README.md
+++ b/apps/example-gcore-js/README.md
@@ -1,0 +1,119 @@
+# Example Gcore MCP Server (JavaScript)
+
+> [!NOTE]
+> This is an internal example MCP server. To get started with [ModelFetch](https://www.modelfetch.com), please visit the [Quick Start documentation](https://www.modelfetch.com/docs/quick-start).
+
+## Quick Start
+
+### Deploying the MCP server
+
+Deploy the MCP server to Gcore:
+
+```bash
+pnpm exec nx deploy example-gcore-js
+```
+
+After deployment, the output will show your MCP server URL.
+
+### Testing with the MCP Inspector
+
+In a separate terminal, run the MCP Inspector to test your server:
+
+```bash
+npx -y @modelcontextprotocol/inspector@latest
+```
+
+Then, connect to your server at the URL shown in the output.
+
+## Project Structure
+
+```
+example-gcore-js/
+├── src/
+│   ├── index.js      # Gcore FastEdge HTTP application
+│   └── server.js     # MCP server implementation
+├── package.json
+└── README.md
+```
+
+## Adding Features
+
+### Tools
+
+Tools provide executable functions to LLMs:
+
+```javascript
+server.registerTool(
+  "my_tool",
+  {
+    title: "My Tool",
+    description: "What this tool does",
+    inputSchema: { param: z.string() },
+  },
+  ({ param }) => ({
+    content: [
+      {
+        type: "text",
+        text: `Result for ${param}`,
+      },
+    ],
+  }),
+);
+```
+
+### Resources
+
+Resources expose data and content to LLMs:
+
+```javascript
+server.registerResource(
+  "my_resource",
+  "resource://my-resource",
+  {
+    title: "My Resource",
+    description: "What this resource does",
+    mimeType: "text/plain",
+  },
+  (uri) => ({
+    contents: [
+      {
+        uri: uri.href,
+        text: "Content of my resource",
+      },
+    ],
+  }),
+);
+```
+
+### Prompts
+
+Prompts are reusable templates for interacting with LLMs:
+
+```javascript
+server.registerPrompt(
+  "my_prompt",
+  {
+    title: "My Prompt",
+    description: "What this prompt does",
+    argsSchema: { arg: z.string() },
+  },
+  ({ arg }) => ({
+    messages: [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: `Prompt with ${arg}`,
+        },
+      },
+    ],
+  }),
+);
+```
+
+## Reading Docs
+
+- [Model Context Protocol - TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
+- [Model Context Protocol - Documentation](https://modelcontextprotocol.io)
+- [ModelFetch - Website](https://www.modelfetch.com)
+- [ModelFetch - Documentation](https://www.modelfetch.com/docs)

--- a/apps/example-gcore-js/package.json
+++ b/apps/example-gcore-js/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "example-gcore-js",
+  "version": "0.16.1",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.17.0",
+    "@modelfetch/gcore": "workspace:^",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@gcoredev/fastedge-sdk-js": "^1.2.2",
+    "modelfetch": "workspace:^"
+  }
+}

--- a/apps/example-gcore-js/src/index.js
+++ b/apps/example-gcore-js/src/index.js
@@ -1,0 +1,5 @@
+import handle from "@modelfetch/gcore";
+
+import server from "./server.js";
+
+handle(server);

--- a/apps/example-gcore-js/src/server.js
+++ b/apps/example-gcore-js/src/server.js
@@ -1,0 +1,70 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import packageJson from "../package.json" with { type: "json" };
+
+const server = new McpServer({
+  title: "Example Gcore MCP Server (JavaScript)",
+  name: packageJson.name,
+  version: packageJson.version,
+});
+
+// Example tool: Roll Dice
+server.registerTool(
+  "roll_dice",
+  {
+    title: "Roll Dice",
+    description: "Rolls an N-sided dice",
+    inputSchema: { sides: z.number().int().min(2) },
+  },
+  ({ sides }) => ({
+    content: [
+      {
+        type: "text",
+        text: `🎲 You rolled a ${1 + Math.floor(Math.random() * sides)}!`,
+      },
+    ],
+  }),
+);
+
+// Example resource: App Config
+server.registerResource(
+  "app_config",
+  "app://config",
+  {
+    title: "App Config",
+    description: "Application configuration: API keys and user settings",
+    mimeType: "text/plain",
+  },
+  (uri) => ({
+    contents: [
+      {
+        uri: uri.href,
+        text: "<APP_CONFIG>",
+      },
+    ],
+  }),
+);
+
+// Example prompt: Review Code
+server.registerPrompt(
+  "review_code",
+  {
+    title: "Review Code",
+    description: "Review code for best practices and potential issues",
+    argsSchema: { code: z.string() },
+  },
+  ({ code }) => ({
+    messages: [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: `Please review this code:\n\n${code}`,
+        },
+      },
+    ],
+  }),
+);
+
+export default server;

--- a/apps/example-gcore-ts/README.md
+++ b/apps/example-gcore-ts/README.md
@@ -1,0 +1,120 @@
+# Example Gcore MCP Server (TypeScript)
+
+> [!NOTE]
+> This is an internal example MCP server. To get started with [ModelFetch](https://www.modelfetch.com), please visit the [Quick Start documentation](https://www.modelfetch.com/docs/quick-start).
+
+## Quick Start
+
+### Deploying the MCP server
+
+Deploy the MCP server to Gcore:
+
+```bash
+pnpm exec nx deploy example-gcore-ts
+```
+
+After deployment, the output will show your MCP server URL.
+
+### Testing with the MCP Inspector
+
+In a separate terminal, run the MCP Inspector to test your server:
+
+```bash
+npx -y @modelcontextprotocol/inspector@latest
+```
+
+Then, connect to your server at the URL shown in the output.
+
+## Project Structure
+
+```
+example-gcore-ts/
+├── src/
+│   ├── index.ts      # Gcore FastEdge HTTP application
+│   └── server.ts     # MCP server implementation
+├── tsconfig.json
+├── package.json
+└── README.md
+```
+
+## Adding Features
+
+### Tools
+
+Tools provide executable functions to LLMs:
+
+```typescript
+server.registerTool(
+  "my_tool",
+  {
+    title: "My Tool",
+    description: "What this tool does",
+    inputSchema: { param: z.string() },
+  },
+  ({ param }) => ({
+    content: [
+      {
+        type: "text",
+        text: `Result for ${param}`,
+      },
+    ],
+  }),
+);
+```
+
+### Resources
+
+Resources expose data and content to LLMs:
+
+```typescript
+server.registerResource(
+  "my_resource",
+  "resource://my-resource",
+  {
+    title: "My Resource",
+    description: "What this resource does",
+    mimeType: "text/plain",
+  },
+  (uri) => ({
+    contents: [
+      {
+        uri: uri.href,
+        text: "Content of my resource",
+      },
+    ],
+  }),
+);
+```
+
+### Prompts
+
+Prompts are reusable templates for interacting with LLMs:
+
+```typescript
+server.registerPrompt(
+  "my_prompt",
+  {
+    title: "My Prompt",
+    description: "What this prompt does",
+    argsSchema: { arg: z.string() },
+  },
+  ({ arg }) => ({
+    messages: [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: `Prompt with ${arg}`,
+        },
+      },
+    ],
+  }),
+);
+```
+
+## Reading Docs
+
+- [Model Context Protocol - TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
+- [Model Context Protocol - Documentation](https://modelcontextprotocol.io)
+- [ModelFetch - Website](https://www.modelfetch.com)
+- [ModelFetch - Documentation](https://www.modelfetch.com/docs)

--- a/apps/example-gcore-ts/eslint.config.js
+++ b/apps/example-gcore-ts/eslint.config.js
@@ -1,0 +1,5 @@
+import createESLintConfig from "create-eslint-config";
+
+const eslintConfig = createESLintConfig();
+
+export default eslintConfig;

--- a/apps/example-gcore-ts/package.json
+++ b/apps/example-gcore-ts/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "example-gcore-ts",
+  "version": "0.16.1",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.17.0",
+    "@modelfetch/gcore": "workspace:^",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@gcoredev/fastedge-sdk-js": "^1.2.2",
+    "create-eslint-config": "workspace:^",
+    "modelfetch": "workspace:^"
+  }
+}

--- a/apps/example-gcore-ts/src/index.ts
+++ b/apps/example-gcore-ts/src/index.ts
@@ -1,0 +1,5 @@
+import handle from "@modelfetch/gcore";
+
+import server from "./server";
+
+handle(server);

--- a/apps/example-gcore-ts/src/server.ts
+++ b/apps/example-gcore-ts/src/server.ts
@@ -1,0 +1,70 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import packageJson from "../package.json" with { type: "json" };
+
+const server = new McpServer({
+  title: "Example Gcore MCP Server (TypeScript)",
+  name: packageJson.name,
+  version: packageJson.version,
+});
+
+// Example tool: Roll Dice
+server.registerTool(
+  "roll_dice",
+  {
+    title: "Roll Dice",
+    description: "Rolls an N-sided dice",
+    inputSchema: { sides: z.number().int().min(2) },
+  },
+  ({ sides }) => ({
+    content: [
+      {
+        type: "text",
+        text: `🎲 You rolled a ${1 + Math.floor(Math.random() * sides)}!`,
+      },
+    ],
+  }),
+);
+
+// Example resource: App Config
+server.registerResource(
+  "app_config",
+  "app://config",
+  {
+    title: "App Config",
+    description: "Application configuration: API keys and user settings",
+    mimeType: "text/plain",
+  },
+  (uri) => ({
+    contents: [
+      {
+        uri: uri.href,
+        text: "<APP_CONFIG>",
+      },
+    ],
+  }),
+);
+
+// Example prompt: Review Code
+server.registerPrompt(
+  "review_code",
+  {
+    title: "Review Code",
+    description: "Review code for best practices and potential issues",
+    argsSchema: { code: z.string() },
+  },
+  ({ code }) => ({
+    messages: [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: `Please review this code:\n\n${code}`,
+        },
+      },
+    ],
+  }),
+);
+
+export default server;

--- a/apps/example-gcore-ts/tsconfig.json
+++ b/apps/example-gcore-ts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "../../libs/modelfetch"
+    },
+    {
+      "path": "../../libs/modelfetch-gcore"
+    }
+  ],
+  "extends": "../../tsconfig.base.json"
+}

--- a/apps/example-gcore-ts/tsconfig.lib.json
+++ b/apps/example-gcore-ts/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../../libs/modelfetch/tsconfig.lib.json"
+    },
+    {
+      "path": "../../libs/modelfetch-gcore/tsconfig.lib.json"
+    }
+  ],
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "sourceRoot": "/apps/example-gcore-ts/src",
+    "rootDir": "src",
+    "outDir": "dist"
+  }
+}

--- a/apps/modelfetch-website/app/layout.tsx
+++ b/apps/modelfetch-website/app/layout.tsx
@@ -52,6 +52,7 @@ export const metadata: Metadata = {
     "Cloudflare",
     "Netlify",
     "Fastly",
+    "Gcore",
     "AWS Lambda",
     "Azure Functions",
   ],

--- a/apps/modelfetch-website/lib/runtime-selector/index.tsx
+++ b/apps/modelfetch-website/lib/runtime-selector/index.tsx
@@ -5,6 +5,7 @@ import {
   SiCloudflare,
   SiDeno,
   SiFastly,
+  SiGcore,
   SiNetlify,
   SiNextdotjs,
   SiNodedotjs,
@@ -132,6 +133,16 @@ export default handle(server);`,
     icon: SiFastly,
     installCommand: "npm install @modelfetch/fastly",
     codeExample: `import handle from "@modelfetch/fastly";
+import server from "./server";
+
+handle(server);`,
+  },
+  {
+    id: "gcore",
+    name: "Gcore",
+    icon: SiGcore,
+    installCommand: "npm install @modelfetch/gcore",
+    codeExample: `import handle from "@modelfetch/gcore";
 import server from "./server";
 
 handle(server);`,

--- a/apps/modelfetch-website/mdx/index.mdx
+++ b/apps/modelfetch-website/mdx/index.mdx
@@ -116,6 +116,13 @@ import server from "./server"; // Import your server
 handle(server); // That's it — ModelFetch handles all runtime-specific details
 ```
 
+```typescript title="src/index.ts" tab="Gcore"
+import handle from "@modelfetch/gcore"; // Choose your runtime
+import server from "./server"; // Import your server
+
+handle(server); // That's it — ModelFetch handles all runtime-specific details
+```
+
 ```typescript title="src/index.ts" tab="AWS Lambda"
 import handle from "@modelfetch/aws-lambda"; // Choose your runtime
 import server from "./server"; // Import your server
@@ -201,6 +208,13 @@ export default handle(server); // That's it — ModelFetch handles all runtime-s
 
 ```typescript title="src/index.ts" tab="Fastly"
 import handle from "@modelfetch/fastly"; // Choose your runtime
+import server from "./server"; // Import your server
+
+handle(server); // That's it — ModelFetch handles all runtime-specific details
+```
+
+```typescript title="src/index.ts" tab="Gcore"
+import handle from "@modelfetch/gcore"; // Choose your runtime
 import server from "./server"; // Import your server
 
 handle(server); // That's it — ModelFetch handles all runtime-specific details

--- a/apps/modelfetch-website/mdx/quick-start.mdx
+++ b/apps/modelfetch-website/mdx/quick-start.mdx
@@ -13,7 +13,7 @@ npx -y create-modelfetch@latest
 
 The CLI will guide you through:
 
-1. **Choosing a runtime** - Node.js, Next.js, Bun, Deno, Vercel, Cloudflare, Netlify, Fastly, AWS Lambda, or Azure Functions
+1. **Choosing a runtime** - Node.js, Next.js, Bun, Deno, Vercel, Cloudflare, Netlify, Fastly, Gcore, AWS Lambda, or Azure Functions
 2. **Selecting a language** - TypeScript or JavaScript
 3. **Picking a package manager** - npm, pnpm, bun, or yarn
 
@@ -51,6 +51,10 @@ npm install @modelfetch/netlify
 
 ```npm title="Terminal" tab="Fastly"
 npm install @modelfetch/fastly
+```
+
+```npm title="Terminal" tab="Gcore"
+npm install @modelfetch/gcore
 ```
 
 ```npm title="Terminal" tab="AWS Lambda"
@@ -162,6 +166,13 @@ export default handle(server); // That's it — ModelFetch handles all runtime-s
 
 ```typescript title="src/index.ts" tab="Fastly"
 import handle from "@modelfetch/fastly"; // Choose your runtime
+import server from "./server"; // Import your server
+
+handle(server); // That's it — ModelFetch handles all runtime-specific details
+```
+
+```typescript title="src/index.ts" tab="Gcore"
+import handle from "@modelfetch/gcore"; // Choose your runtime
 import server from "./server"; // Import your server
 
 handle(server); // That's it — ModelFetch handles all runtime-specific details

--- a/apps/modelfetch-website/mdx/runtime/gcore.mdx
+++ b/apps/modelfetch-website/mdx/runtime/gcore.mdx
@@ -1,0 +1,30 @@
+---
+title: Gcore
+description: Deploy MCP servers to Gcore
+---
+
+The `@modelfetch/gcore` package lets you deploy MCP servers to [Gcore](https://gcore.com).
+
+## Installation
+
+```npm title="Terminal"
+npm install @modelfetch/gcore
+```
+
+## Usage
+
+```typescript title="src/index.ts"
+import handle from "@modelfetch/gcore";
+import server from "./server"; // Import your McpServer
+
+// Run as a Gcore FastEdge HTTP application
+handle(server);
+```
+
+## API Reference
+
+### `handle(server)`
+
+Starts the MCP server
+
+- **server**: Required [`McpServer`](https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#server) instance from [`@modelcontextprotocol/sdk`](https://github.com/modelcontextprotocol/typescript-sdk)

--- a/apps/modelfetch-website/mdx/runtime/index.mdx
+++ b/apps/modelfetch-website/mdx/runtime/index.mdx
@@ -49,6 +49,11 @@ ModelFetch provides runtime-specific packages that handle tedious platform diffe
     href="/docs/runtime/fastly"
   />
   <Card
+    title="Gcore"
+    description="Deploy MCP servers to Gcore"
+    href="/docs/runtime/gcore"
+  />
+  <Card
     title="AWS Lambda"
     description="Deploy MCP servers to AWS Lambda"
     href="/docs/runtime/aws-lambda"

--- a/apps/modelfetch-website/mdx/runtime/meta.json
+++ b/apps/modelfetch-website/mdx/runtime/meta.json
@@ -9,6 +9,7 @@
     "cloudflare",
     "netlify",
     "fastly",
+    "gcore",
     "aws-lambda",
     "azure-functions"
   ]

--- a/libs/create-modelfetch/README.md
+++ b/libs/create-modelfetch/README.md
@@ -7,7 +7,7 @@ Scaffold a new MCP server with ModelFetch.
 
 ## Features
 
-- **Multiple Runtimes**: Node.js, Next.js, Bun, Deno, Vercel, Cloudflare, Netlify, Fastly, AWS Lambda, and Azure Functions
+- **Multiple Runtimes**: Node.js, Next.js, Bun, Deno, Vercel, Cloudflare, Netlify, Fastly, Gcore, AWS Lambda, and Azure Functions
 - **Multiple Languages**: TypeScript and JavaScript
 - **Multiple Package Managers**: `npm`, `pnpm`, `bun`, and `yarn`
 - **Multiple CLI Initializers**: `npx`, `npm init`, `npm create`, `pnpm dlx`, `pnpm create`, `bun x`, `bun create`, `deno`, and `yarn`

--- a/libs/create-modelfetch/src/index.ts
+++ b/libs/create-modelfetch/src/index.ts
@@ -49,6 +49,8 @@ const packageVersions = {
   "@modelfetch/netlify": packageJson.version,
   "@modelfetch/fastly": packageJson.version,
   "@fastly/js-compute": "3.34.0",
+  "@modelfetch/gcore": packageJson.version,
+  "@gcoredev/fastedge-sdk-js": "1.2.2",
   "@modelfetch/azure-functions": packageJson.version,
   "@azure/functions": "4.7.2",
 };
@@ -65,6 +67,7 @@ type Runtime =
   | "cloudflare"
   | "netlify"
   | "fastly"
+  | "gcore"
   | "aws-lambda"
   | "azure-functions";
 type Language = "javascript" | "typescript";
@@ -127,7 +130,8 @@ function getStartCommand(
     case "deno": {
       return "deno task start";
     }
-    case "aws-lambda": {
+    case "aws-lambda":
+    case "gcore": {
       return `${packageManager} run deploy`;
     }
     case "next":
@@ -255,6 +259,7 @@ async function main() {
       { value: "cloudflare", label: "Cloudflare" },
       { value: "netlify", label: "Netlify" },
       { value: "fastly", label: "Fastly" },
+      { value: "gcore", label: "Gcore" },
       { value: "aws-lambda", label: "AWS Lambda" },
       { value: "azure-functions", label: "Azure Functions" },
     ],

--- a/libs/create-modelfetch/templates/gcore-js/.gitignore.template
+++ b/libs/create-modelfetch/templates/gcore-js/.gitignore.template
@@ -1,0 +1,3 @@
+.DS_Store
+node_modules
+dist

--- a/libs/create-modelfetch/templates/gcore-js/README.md.template
+++ b/libs/create-modelfetch/templates/gcore-js/README.md.template
@@ -1,0 +1,119 @@
+# <%= projectTitle %>
+
+An MCP server built with [ModelFetch](https://www.modelfetch.com)
+
+## Quick Start
+
+### Deploying the MCP server
+
+Deploy the MCP server to Gcore:
+
+```bash
+<%= packageManager %> run deploy
+```
+
+After deployment, the output will show your MCP server URL.
+
+### Testing with the MCP Inspector
+
+In a separate terminal, run the MCP Inspector to test your server:
+
+```bash
+npx -y @modelcontextprotocol/inspector@latest
+```
+
+Then, connect to your server at the URL shown in the output.
+
+## Project Structure
+
+```
+<%= projectName %>/
+├── src/
+│   ├── index.js      # Gcore FastEdge HTTP application
+│   └── server.js     # MCP server implementation
+├── package.json
+└── README.md
+```
+
+## Adding Features
+
+### Tools
+
+Tools provide executable functions to LLMs:
+
+```javascript
+server.registerTool(
+  "my_tool",
+  {
+    title: "My Tool",
+    description: "What this tool does",
+    inputSchema: { param: z.string() },
+  },
+  ({ param }) => ({
+    content: [
+      {
+        type: "text",
+        text: `Result for ${param}`,
+      },
+    ],
+  }),
+);
+```
+
+### Resources
+
+Resources expose data and content to LLMs:
+
+```javascript
+server.registerResource(
+  "my_resource",
+  "resource://my-resource",
+  {
+    title: "My Resource",
+    description: "What this resource does",
+    mimeType: "text/plain",
+  },
+  (uri) => ({
+    contents: [
+      {
+        uri: uri.href,
+        text: "Content of my resource",
+      },
+    ],
+  }),
+);
+```
+
+### Prompts
+
+Prompts are reusable templates for interacting with LLMs:
+
+```javascript
+server.registerPrompt(
+  "my_prompt",
+  {
+    title: "My Prompt",
+    description: "What this prompt does",
+    argsSchema: { arg: z.string() },
+  },
+  ({ arg }) => ({
+    messages: [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: `Prompt with ${arg}`,
+        },
+      },
+    ],
+  }),
+);
+```
+
+## Reading Docs
+
+- [Model Context Protocol - Documentation](https://modelcontextprotocol.io)
+- [Model Context Protocol - TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
+- [ModelFetch - Website](https://www.modelfetch.com)
+- [ModelFetch - Documentation](https://www.modelfetch.com/docs)
+- [ModelFetch - GitHub](https://github.com/phuctm97/modelfetch)

--- a/libs/create-modelfetch/templates/gcore-js/README.md.template
+++ b/libs/create-modelfetch/templates/gcore-js/README.md.template
@@ -31,6 +31,7 @@ Then, connect to your server at the URL shown in the output.
 ├── src/
 │   ├── index.js      # Gcore FastEdge HTTP application
 │   └── server.js     # MCP server implementation
+├── deploy.js         # Gcore FastEdge deployment script
 ├── package.json
 └── README.md
 ```

--- a/libs/create-modelfetch/templates/gcore-js/deploy.js.template
+++ b/libs/create-modelfetch/templates/gcore-js/deploy.js.template
@@ -1,0 +1,78 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const packageJson = JSON.parse(await readFile("package.json", "utf8"));
+const appName = packageJson.name || path.basename(process.cwd());
+const apiKey = process.env.GCORE_API_KEY;
+
+if (!apiKey) {
+  throw new Error("GCORE_API_KEY environment variable is required");
+}
+
+const uploadResponse = await fetch(
+  "https://api.gcore.com/fastedge/v1/binaries/raw",
+  {
+    method: "POST",
+    headers: {
+      authorization: `apikey ${apiKey}`,
+      "content-type": "application/octet-stream",
+    },
+    body: await readFile(path.resolve("dist", "index.wasm")),
+  }
+);
+
+if (!uploadResponse.ok) {
+  throw new Error(
+    `Failed to upload binary: ${uploadResponse.status} ${await uploadResponse.text()}`
+  );
+}
+
+const uploadResult = await uploadResponse.json();
+
+const listUrl = new URL("https://api.gcore.com/fastedge/v1/apps");
+listUrl.searchParams.set("name", appName);
+
+const listResponse = await fetch(listUrl, {
+  method: "GET",
+  headers: { authorization: `apikey ${apiKey}` },
+});
+
+let app = null;
+if (listResponse.ok) {
+  const listResult = await listResponse.json();
+  app = listResult.apps.find((a) => a.name === appName);
+} else if (listResponse.status !== 404) {
+  throw new Error(
+    `Failed to list applications: ${listResponse.status} ${await listResponse.text()}`
+  );
+}
+
+const deployResponse = await (app
+  ? fetch(`https://api.gcore.com/fastedge/v1/apps/${app.id}`, {
+      method: "PATCH",
+      headers: {
+        authorization: `apikey ${apiKey}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ binary: uploadResult.id, status: 1 }),
+    })
+  : fetch("https://api.gcore.com/fastedge/v1/apps", {
+      method: "POST",
+      headers: {
+        authorization: `apikey ${apiKey}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        name: appName,
+        binary: uploadResult.id,
+        status: 1,
+      }),
+    }));
+
+if (!deployResponse.ok) {
+  throw new Error(
+    `Failed to ${app ? "update" : "create"} application: ${deployResponse.status} ${await deployResponse.text()}`
+  );
+}
+
+console.log((await deployResponse.json()).url);

--- a/libs/create-modelfetch/templates/gcore-js/package.json.template
+++ b/libs/create-modelfetch/templates/gcore-js/package.json.template
@@ -1,0 +1,20 @@
+{
+  "name": "<%= projectName %>",
+  "version": "0.0.1",
+  "description": "<%= projectTitle %> (built with ModelFetch)",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "fastedge-build ./src/index.js ./dist/index.wasm",
+    "deploy": "echo 'Use Gcore CLI to deploy your FastEdge HTTP application'"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "<%= versions['@modelcontextprotocol/sdk'] %>",
+    "@modelfetch/gcore": "<%= versions['@modelfetch/gcore'] %>",
+    "tslib": "<%= versions['tslib'] %>",
+    "zod": "<%= versions['zod'] %>"
+  },
+  "devDependencies": {
+    "@gcoredev/fastedge-sdk-js": "<%= versions['@gcoredev/fastedge-sdk-js'] %>"
+  }
+}

--- a/libs/create-modelfetch/templates/gcore-js/package.json.template
+++ b/libs/create-modelfetch/templates/gcore-js/package.json.template
@@ -5,8 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "fastedge-build ./src/index.js ./dist/index.wasm",
-    "deploy": "echo 'Use Gcore CLI to deploy your FastEdge HTTP application'"
+    "deploy": "fastedge-build ./src/index.js ./dist/index.wasm && node deploy.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "<%= versions['@modelcontextprotocol/sdk'] %>",

--- a/libs/create-modelfetch/templates/gcore-js/src/index.js.template
+++ b/libs/create-modelfetch/templates/gcore-js/src/index.js.template
@@ -1,0 +1,5 @@
+import handle from "@modelfetch/gcore";
+
+import server from "./server.js";
+
+handle(server);

--- a/libs/create-modelfetch/templates/gcore-js/src/server.js.template
+++ b/libs/create-modelfetch/templates/gcore-js/src/server.js.template
@@ -1,0 +1,70 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import packageJson from "../package.json" with { type: "json" };
+
+const server = new McpServer({
+  title: "<%= title %>",
+  name: packageJson.name,
+  version: packageJson.version,
+});
+
+// Example tool: Roll Dice
+server.registerTool(
+  "roll_dice",
+  {
+    title: "Roll Dice",
+    description: "Rolls an N-sided dice",
+    inputSchema: { sides: z.number().int().min(2) },
+  },
+  ({ sides }) => ({
+    content: [
+      {
+        type: "text",
+        text: `🎲 You rolled a ${1 + Math.floor(Math.random() * sides)}!`,
+      },
+    ],
+  }),
+);
+
+// Example resource: App Config
+server.registerResource(
+  "app_config",
+  "app://config",
+  {
+    title: "App Config",
+    description: "Application configuration: API keys and user settings",
+    mimeType: "text/plain",
+  },
+  (uri) => ({
+    contents: [
+      {
+        uri: uri.href,
+        text: "<APP_CONFIG>",
+      },
+    ],
+  }),
+);
+
+// Example prompt: Review Code
+server.registerPrompt(
+  "review_code",
+  {
+    title: "Review Code",
+    description: "Review code for best practices and potential issues",
+    argsSchema: { code: z.string() },
+  },
+  ({ code }) => ({
+    messages: [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: `Please review this code:\n\n${code}`,
+        },
+      },
+    ],
+  }),
+);
+
+export default server;

--- a/libs/create-modelfetch/templates/gcore-ts/.gitignore.template
+++ b/libs/create-modelfetch/templates/gcore-ts/.gitignore.template
@@ -1,0 +1,4 @@
+.DS_Store
+node_modules
+dist
+*.tsbuildinfo

--- a/libs/create-modelfetch/templates/gcore-ts/README.md.template
+++ b/libs/create-modelfetch/templates/gcore-ts/README.md.template
@@ -1,0 +1,120 @@
+# <%= projectTitle %>
+
+An MCP server built with [ModelFetch](https://www.modelfetch.com)
+
+## Quick Start
+
+### Deploying the MCP server
+
+Deploy the MCP server to Gcore:
+
+```bash
+<%= packageManager %> run deploy
+```
+
+After deployment, the output will show your MCP server URL.
+
+### Testing with the MCP Inspector
+
+In a separate terminal, run the MCP Inspector to test your server:
+
+```bash
+npx -y @modelcontextprotocol/inspector@latest
+```
+
+Then, connect to your server at the URL shown in the output.
+
+## Project Structure
+
+```
+<%= projectName %>/
+├── src/
+│   ├── index.ts      # Gcore FastEdge HTTP application
+│   └── server.ts     # MCP server implementation
+├── tsconfig.json
+├── package.json
+└── README.md
+```
+
+## Adding Features
+
+### Tools
+
+Tools provide executable functions to LLMs:
+
+```typescript
+server.registerTool(
+  "my_tool",
+  {
+    title: "My Tool",
+    description: "What this tool does",
+    inputSchema: { param: z.string() },
+  },
+  ({ param }) => ({
+    content: [
+      {
+        type: "text",
+        text: `Result for ${param}`,
+      },
+    ],
+  }),
+);
+```
+
+### Resources
+
+Resources expose data and content to LLMs:
+
+```typescript
+server.registerResource(
+  "my_resource",
+  "resource://my-resource",
+  {
+    title: "My Resource",
+    description: "What this resource does",
+    mimeType: "text/plain",
+  },
+  (uri) => ({
+    contents: [
+      {
+        uri: uri.href,
+        text: "Content of my resource",
+      },
+    ],
+  }),
+);
+```
+
+### Prompts
+
+Prompts are reusable templates for interacting with LLMs:
+
+```typescript
+server.registerPrompt(
+  "my_prompt",
+  {
+    title: "My Prompt",
+    description: "What this prompt does",
+    argsSchema: { arg: z.string() },
+  },
+  ({ arg }) => ({
+    messages: [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: `Prompt with ${arg}`,
+        },
+      },
+    ],
+  }),
+);
+```
+
+## Reading Docs
+
+- [Model Context Protocol - Documentation](https://modelcontextprotocol.io)
+- [Model Context Protocol - TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
+- [ModelFetch - Website](https://www.modelfetch.com)
+- [ModelFetch - Documentation](https://www.modelfetch.com/docs)
+- [ModelFetch - GitHub](https://github.com/phuctm97/modelfetch)

--- a/libs/create-modelfetch/templates/gcore-ts/README.md.template
+++ b/libs/create-modelfetch/templates/gcore-ts/README.md.template
@@ -31,6 +31,7 @@ Then, connect to your server at the URL shown in the output.
 ├── src/
 │   ├── index.ts      # Gcore FastEdge HTTP application
 │   └── server.ts     # MCP server implementation
+├── deploy.js         # Gcore FastEdge deployment script
 ├── tsconfig.json
 ├── package.json
 └── README.md

--- a/libs/create-modelfetch/templates/gcore-ts/deploy.js.template
+++ b/libs/create-modelfetch/templates/gcore-ts/deploy.js.template
@@ -1,0 +1,78 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const packageJson = JSON.parse(await readFile("package.json", "utf8"));
+const appName = packageJson.name || path.basename(process.cwd());
+const apiKey = process.env.GCORE_API_KEY;
+
+if (!apiKey) {
+  throw new Error("GCORE_API_KEY environment variable is required");
+}
+
+const uploadResponse = await fetch(
+  "https://api.gcore.com/fastedge/v1/binaries/raw",
+  {
+    method: "POST",
+    headers: {
+      authorization: `apikey ${apiKey}`,
+      "content-type": "application/octet-stream",
+    },
+    body: await readFile(path.resolve("dist", "index.wasm")),
+  }
+);
+
+if (!uploadResponse.ok) {
+  throw new Error(
+    `Failed to upload binary: ${uploadResponse.status} ${await uploadResponse.text()}`
+  );
+}
+
+const uploadResult = await uploadResponse.json();
+
+const listUrl = new URL("https://api.gcore.com/fastedge/v1/apps");
+listUrl.searchParams.set("name", appName);
+
+const listResponse = await fetch(listUrl, {
+  method: "GET",
+  headers: { authorization: `apikey ${apiKey}` },
+});
+
+let app = null;
+if (listResponse.ok) {
+  const listResult = await listResponse.json();
+  app = listResult.apps.find((a) => a.name === appName);
+} else if (listResponse.status !== 404) {
+  throw new Error(
+    `Failed to list applications: ${listResponse.status} ${await listResponse.text()}`
+  );
+}
+
+const deployResponse = await (app
+  ? fetch(`https://api.gcore.com/fastedge/v1/apps/${app.id}`, {
+      method: "PATCH",
+      headers: {
+        authorization: `apikey ${apiKey}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ binary: uploadResult.id, status: 1 }),
+    })
+  : fetch("https://api.gcore.com/fastedge/v1/apps", {
+      method: "POST",
+      headers: {
+        authorization: `apikey ${apiKey}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        name: appName,
+        binary: uploadResult.id,
+        status: 1,
+      }),
+    }));
+
+if (!deployResponse.ok) {
+  throw new Error(
+    `Failed to ${app ? "update" : "create"} application: ${deployResponse.status} ${await deployResponse.text()}`
+  );
+}
+
+console.log((await deployResponse.json()).url);

--- a/libs/create-modelfetch/templates/gcore-ts/package.json.template
+++ b/libs/create-modelfetch/templates/gcore-ts/package.json.template
@@ -5,8 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc -b && fastedge-build ./dist/index.js ./dist/index.wasm",
-    "deploy": "echo 'Use Gcore CLI to deploy your FastEdge HTTP application'"
+    "deploy": "tsc -b && fastedge-build ./dist/index.js ./dist/index.wasm && node deploy.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "<%= versions['@modelcontextprotocol/sdk'] %>",

--- a/libs/create-modelfetch/templates/gcore-ts/package.json.template
+++ b/libs/create-modelfetch/templates/gcore-ts/package.json.template
@@ -1,0 +1,21 @@
+{
+  "name": "<%= projectName %>",
+  "version": "0.0.1",
+  "description": "<%= projectTitle %> (built with ModelFetch)",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -b && fastedge-build ./dist/index.js ./dist/index.wasm",
+    "deploy": "echo 'Use Gcore CLI to deploy your FastEdge HTTP application'"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "<%= versions['@modelcontextprotocol/sdk'] %>",
+    "@modelfetch/gcore": "<%= versions['@modelfetch/gcore'] %>",
+    "tslib": "<%= versions['tslib'] %>",
+    "zod": "<%= versions['zod'] %>"
+  },
+  "devDependencies": {
+    "@gcoredev/fastedge-sdk-js": "<%= versions['@gcoredev/fastedge-sdk-js'] %>",
+    "typescript": "<%= versions['typescript'] %>"
+  }
+}

--- a/libs/create-modelfetch/templates/gcore-ts/src/index.ts.template
+++ b/libs/create-modelfetch/templates/gcore-ts/src/index.ts.template
@@ -1,0 +1,5 @@
+import handle from "@modelfetch/gcore";
+
+import server from "./server";
+
+handle(server);

--- a/libs/create-modelfetch/templates/gcore-ts/src/server.ts.template
+++ b/libs/create-modelfetch/templates/gcore-ts/src/server.ts.template
@@ -1,0 +1,70 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import packageJson from "../package.json" with { type: "json" };
+
+const server = new McpServer({
+  title: "<%= title %>",
+  name: packageJson.name,
+  version: packageJson.version,
+});
+
+// Example tool: Roll Dice
+server.registerTool(
+  "roll_dice",
+  {
+    title: "Roll Dice",
+    description: "Rolls an N-sided dice",
+    inputSchema: { sides: z.number().int().min(2) },
+  },
+  ({ sides }) => ({
+    content: [
+      {
+        type: "text",
+        text: `🎲 You rolled a ${1 + Math.floor(Math.random() * sides)}!`,
+      },
+    ],
+  }),
+);
+
+// Example resource: App Config
+server.registerResource(
+  "app_config",
+  "app://config",
+  {
+    title: "App Config",
+    description: "Application configuration: API keys and user settings",
+    mimeType: "text/plain",
+  },
+  (uri) => ({
+    contents: [
+      {
+        uri: uri.href,
+        text: "<APP_CONFIG>",
+      },
+    ],
+  }),
+);
+
+// Example prompt: Review Code
+server.registerPrompt(
+  "review_code",
+  {
+    title: "Review Code",
+    description: "Review code for best practices and potential issues",
+    argsSchema: { arg: z.string() },
+  },
+  ({ code }) => ({
+    messages: [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: `Please review this code:\n\n${code}`,
+        },
+      },
+    ],
+  }),
+);
+
+export default server;

--- a/libs/create-modelfetch/templates/gcore-ts/tsconfig.json.template
+++ b/libs/create-modelfetch/templates/gcore-ts/tsconfig.json.template
@@ -1,0 +1,18 @@
+{
+  "include": ["src"],
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "target": "es2022",
+    "lib": ["es2023"],
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "incremental": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "importHelpers": true,
+    "skipLibCheck": true
+  }
+}

--- a/libs/modelfetch-core/README.md
+++ b/libs/modelfetch-core/README.md
@@ -17,5 +17,6 @@
 - [@modelfetch/cloudflare](https://www.npmjs.com/package/@modelfetch/cloudflare) for Cloudflare
 - [@modelfetch/netlify](https://www.npmjs.com/package/@modelfetch/netlify) for Netlify
 - [@modelfetch/fastly](https://www.npmjs.com/package/@modelfetch/fastly) for Fastly
+- [@modelfetch/gcore](https://www.npmjs.com/package/@modelfetch/gcore) for Gcore
 - [@modelfetch/aws-lambda](https://www.npmjs.com/package/@modelfetch/aws-lambda) for AWS Lambda
 - [@modelfetch/azure-functions](https://www.npmjs.com/package/@modelfetch/azure-functions) for Azure Functions

--- a/libs/modelfetch-gcore/README.md
+++ b/libs/modelfetch-gcore/README.md
@@ -1,0 +1,31 @@
+# `@modelfetch/gcore`
+
+[![npm version](https://img.shields.io/npm/v/@modelfetch/gcore)](https://www.npmjs.com/package/@modelfetch/gcore)
+[![npm license](https://img.shields.io/npm/l/@modelfetch/gcore)](https://www.npmjs.com/package/@modelfetch/gcore)
+[![docs](https://img.shields.io/badge/docs-modelfetch.com-blue)](https://www.modelfetch.com/docs/runtime/gcore)
+
+Deploy MCP servers to Gcore.
+
+## Installation
+
+```bash
+npm install @modelfetch/gcore
+```
+
+## Usage
+
+```typescript
+import handle from "@modelfetch/gcore";
+import server from "./server"; // Import your McpServer
+
+// Run as a Gcore FastEdge HTTP application
+handle(server);
+```
+
+## API Reference
+
+### `handle(server)`
+
+Starts the MCP server
+
+- **server**: Required [`McpServer`](https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#server) instance from [`@modelcontextprotocol/sdk`](https://github.com/modelcontextprotocol/typescript-sdk)

--- a/libs/modelfetch-gcore/eslint.config.js
+++ b/libs/modelfetch-gcore/eslint.config.js
@@ -1,0 +1,5 @@
+import createESLintConfig from "create-eslint-config";
+
+const eslintConfig = createESLintConfig();
+
+export default eslintConfig;

--- a/libs/modelfetch-gcore/package.json
+++ b/libs/modelfetch-gcore/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@modelfetch/gcore",
+  "version": "0.16.1",
+  "description": "Gcore runtime adapter for MCP servers built with ModelFetch",
+  "keywords": [
+    "model-context-protocol",
+    "mcp",
+    "mcp-server",
+    "ai",
+    "ai-integration",
+    "sdk",
+    "typescript-sdk",
+    "javascript-sdk"
+  ],
+  "homepage": "https://www.modelfetch.com",
+  "bugs": {
+    "url": "https://github.com/phuctm97/modelfetch/issues",
+    "email": "phuctm97@gmail.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/phuctm97/modelfetch.git",
+    "directory": "libs/modelfetch-gcore"
+  },
+  "license": "MIT",
+  "author": {
+    "name": "Minh-Phuc Tran",
+    "email": "phuctm97@gmail.com",
+    "url": "https://x.com/phuctm97"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@modelfetch/core": "workspace:^",
+    "hono": "^4.8.10"
+  },
+  "devDependencies": {
+    "create-eslint-config": "workspace:^"
+  }
+}

--- a/libs/modelfetch-gcore/src/index.ts
+++ b/libs/modelfetch-gcore/src/index.ts
@@ -1,0 +1,9 @@
+import type { ServerOrConfig } from "@modelfetch/core";
+
+import { createApp } from "@modelfetch/core";
+import { fire } from "hono/service-worker";
+
+export default function handle(arg: ServerOrConfig) {
+  const app = createApp(arg);
+  fire(app);
+}

--- a/libs/modelfetch-gcore/tsconfig.json
+++ b/libs/modelfetch-gcore/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "../modelfetch-core"
+    }
+  ],
+  "extends": "../../tsconfig.base.json"
+}

--- a/libs/modelfetch-gcore/tsconfig.lib.json
+++ b/libs/modelfetch-gcore/tsconfig.lib.json
@@ -1,0 +1,14 @@
+{
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../modelfetch-core/tsconfig.lib.json"
+    }
+  ],
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "sourceRoot": "/libs/modelfetch-gcore/src",
+    "rootDir": "src",
+    "outDir": "dist"
+  }
+}

--- a/libs/modelfetch/README.md
+++ b/libs/modelfetch/README.md
@@ -16,5 +16,6 @@
 - [@modelfetch/cloudflare](https://www.npmjs.com/package/@modelfetch/cloudflare) for Cloudflare
 - [@modelfetch/netlify](https://www.npmjs.com/package/@modelfetch/netlify) for Netlify
 - [@modelfetch/fastly](https://www.npmjs.com/package/@modelfetch/fastly) for Fastly
+- [@modelfetch/gcore](https://www.npmjs.com/package/@modelfetch/gcore) for Gcore
 - [@modelfetch/aws-lambda](https://www.npmjs.com/package/@modelfetch/aws-lambda) for AWS Lambda
 - [@modelfetch/azure-functions](https://www.npmjs.com/package/@modelfetch/azure-functions) for Azure Functions

--- a/libs/nx-10x/src/executors/deploy-gcore-fastedge/index.ts
+++ b/libs/nx-10x/src/executors/deploy-gcore-fastedge/index.ts
@@ -1,0 +1,85 @@
+import type { ExecutorContext } from "@nx/devkit";
+
+import { logger } from "@nx/devkit";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+interface App {
+  id: number;
+  name: string;
+}
+
+export default async function deployGcoreFastedgeExecutor(
+  options: object,
+  context: ExecutorContext,
+): Promise<{ success: boolean }> {
+  if (!context.projectName) return { success: false };
+  const project = context.projectsConfigurations.projects[context.projectName];
+  const uploadResponse = await fetch(
+    "https://api.gcore.com/fastedge/v1/binaries/raw",
+    {
+      method: "POST",
+      headers: {
+        authorization: `apikey ${process.env.GCORE_API_KEY}`,
+        "content-type": "application/octet-stream",
+      },
+      body: await readFile(path.resolve(project.root, "dist", "index.wasm")),
+    },
+  );
+  if (!uploadResponse.ok) {
+    logger.error(
+      `Failed to upload binary: ${uploadResponse.status} ${await uploadResponse.text()}`,
+    );
+    return { success: false };
+  }
+  const uploadResult = (await uploadResponse.json()) as { id: number };
+  const listUrl = new URL("https://api.gcore.com/fastedge/v1/apps");
+  listUrl.searchParams.set("name", context.projectName);
+  const listResponse = await fetch(listUrl, {
+    method: "GET",
+    headers: { authorization: `apikey ${process.env.GCORE_API_KEY}` },
+  });
+  const apps: App[] = [];
+  if (listResponse.ok) {
+    const listResult = (await listResponse.json()) as { apps: App[] };
+    apps.push(...listResult.apps);
+  } else if (listResponse.status !== 404) {
+    logger.error(
+      `Failed to list applications: ${listResponse.status} ${await listResponse.text()}`,
+    );
+    return { success: false };
+  }
+  const app = apps.find((app) => app.name === context.projectName);
+  const createOrUpdateResponse = await (app
+    ? fetch(`https://api.gcore.com/fastedge/v1/apps/${app.id}`, {
+        method: "PATCH",
+        headers: {
+          authorization: `apikey ${process.env.GCORE_API_KEY}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ binary: uploadResult.id, status: 1 }),
+      })
+    : fetch("https://api.gcore.com/fastedge/v1/apps", {
+        method: "POST",
+        headers: {
+          authorization: `apikey ${process.env.GCORE_API_KEY}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          name: context.projectName,
+          binary: uploadResult.id,
+          status: 1,
+        }),
+      }));
+  if (!createOrUpdateResponse.ok) {
+    logger.error(
+      `Failed to create or update application: ${createOrUpdateResponse.status} ${await createOrUpdateResponse.text()}`,
+    );
+    return { success: false };
+  }
+  const createOrUpdateResult = (await createOrUpdateResponse.json()) as {
+    url: string;
+  };
+  logger.info(`URL: ${createOrUpdateResult.url}`);
+  return { success: true };
+}

--- a/libs/nx-10x/src/executors/deploy-gcore-fastedge/schema.json
+++ b/libs/nx-10x/src/executors/deploy-gcore-fastedge/schema.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/libs/nx-10x/src/executors/index.json
+++ b/libs/nx-10x/src/executors/index.json
@@ -4,6 +4,11 @@
       "description": "Prepare for release publishing.",
       "implementation": "./prepare-release-publish/index.ts",
       "schema": "./prepare-release-publish/schema.json"
+    },
+    "deploy-gcore-fastedge": {
+      "description": "Deploy a Gcore FastEdge application",
+      "implementation": "./deploy-gcore-fastedge/index.ts",
+      "schema": "./deploy-gcore-fastedge/schema.json"
     }
   }
 }

--- a/libs/nx-10x/src/index.ts
+++ b/libs/nx-10x/src/index.ts
@@ -220,6 +220,30 @@ export const createNodesV2: CreateNodesV2 = [
               dependsOn: ["build", "^build"],
             };
           }
+          if (
+            packageJson.dependencies?.["@modelfetch/gcore"] ||
+            packageJson.devDependencies?.["@modelfetch/gcore"]
+          ) {
+            useDefaultStartCommand = false;
+            targets["build-wasm"] = {
+              cache: true,
+              command: `fastedge-build ${fs.existsSync(path.join(projectRoot, "tsconfig.json")) ? "./dist/index.js" : "./src/index.js"} ./dist/index.wasm`,
+              options: { cwd: "{projectRoot}" },
+              inputs: [
+                "production",
+                "^production",
+                { dependentTasksOutputFiles: "**/*.js" },
+                { externalDependencies: ["typescript", "tslib"] },
+              ],
+              outputs: ["{projectRoot}/dist/index.wasm"],
+              dependsOn: ["build", "^build"],
+            };
+            targets.deploy = {
+              executor: "nx-10x:deploy-gcore-fastedge",
+              options: { cwd: "{projectRoot}" },
+              dependsOn: ["build-wasm"],
+            };
+          }
           if (useDefaultStartCommand) {
             const defaultStartCommand = getDefaultStartCommand(
               projectRoot,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,6 +310,47 @@ importers:
         specifier: workspace:^
         version: link:../../libs/modelfetch
 
+  apps/example-gcore-js:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.17.0
+        version: 1.17.0
+      '@modelfetch/gcore':
+        specifier: workspace:^
+        version: link:../../libs/modelfetch-gcore
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@gcoredev/fastedge-sdk-js':
+        specifier: ^1.2.2
+        version: 1.2.2
+      modelfetch:
+        specifier: workspace:^
+        version: link:../../libs/modelfetch
+
+  apps/example-gcore-ts:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.17.0
+        version: 1.17.0
+      '@modelfetch/gcore':
+        specifier: workspace:^
+        version: link:../../libs/modelfetch-gcore
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@gcoredev/fastedge-sdk-js':
+        specifier: ^1.2.2
+        version: 1.2.2
+      create-eslint-config:
+        specifier: workspace:^
+        version: link:../../libs/create-eslint-config
+      modelfetch:
+        specifier: workspace:^
+        version: link:../../libs/modelfetch
+
   apps/example-netlify-js:
     dependencies:
       '@modelcontextprotocol/sdk':
@@ -784,6 +825,19 @@ importers:
       abortcontroller-polyfill:
         specifier: ^1.7.8
         version: 1.7.8
+      hono:
+        specifier: ^4.8.10
+        version: 4.8.10
+    devDependencies:
+      create-eslint-config:
+        specifier: workspace:^
+        version: link:../create-eslint-config
+
+  libs/modelfetch-gcore:
+    dependencies:
+      '@modelfetch/core':
+        specifier: workspace:^
+        version: link:../modelfetch-core
       hono:
         specifier: ^4.8.10
         version: 4.8.10
@@ -1413,6 +1467,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/regjsgen@0.8.0':
+    resolution: {integrity: sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==}
+
   '@babel/runtime@7.28.2':
     resolution: {integrity: sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==}
     engines: {node: '>=6.9.0'}
@@ -1444,9 +1501,21 @@ packages:
     resolution: {integrity: sha512-+GCKtZXhPj7qyDl5pR0F3PTEk8tWINV8dv1tUbKMjMXvqjHIkvzalkWo5ZL2kCKwh8Bwn8rWpSmyvRC/Nlu9nQ==}
     engines: {node: '>=16'}
 
+  '@bytecodealliance/wizer-darwin-arm64@3.0.1':
+    resolution: {integrity: sha512-/8KYSajyhO9koAE3qQhYfC6belZheJw9X3XqW7hrizTpj6n4z4OJFhhqwJmiYFUUsPtC7OxcXMFFPbTuSQPBcw==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
   '@bytecodealliance/wizer-darwin-arm64@7.0.5':
     resolution: {integrity: sha512-Tp0SgVQR568SVPvSfyWDT00yL4ry/w9FS2qy8ZwaP0EauYyjFSZojj6mESX6x9fpYkEnQdprgfdvhw5h1hTwCQ==}
     cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  '@bytecodealliance/wizer-darwin-x64@3.0.1':
+    resolution: {integrity: sha512-bMReultN/r+W/BRXV0F+28U5dZwbQT/ZO0k4icZlhUhrv5/wpQJix7Z/ZvBnVQ+/JHb0QDUpFk2/zCtgkRXP6Q==}
+    cpu: [x64]
     os: [darwin]
     hasBin: true
 
@@ -1456,9 +1525,21 @@ packages:
     os: [darwin]
     hasBin: true
 
+  '@bytecodealliance/wizer-linux-arm64@3.0.1':
+    resolution: {integrity: sha512-35ZhAeYxWK3bTqqgwysbBWlGlrlMNKNng3ZITQV2PAtafpE7aCeqywl7VAS4lLRG5eTb7wxNgN7zf8d3wiIFTQ==}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
+
   '@bytecodealliance/wizer-linux-arm64@7.0.5':
     resolution: {integrity: sha512-01qqaiIWrYXPt2bjrfiluSSOmUL/PMjPtJlYa/XqZgK75g3RVn3sRkSflwoCXtXMRbHdb03qNrJ9w81+F17kvA==}
     cpu: [arm64]
+    os: [linux]
+    hasBin: true
+
+  '@bytecodealliance/wizer-linux-s390x@3.0.1':
+    resolution: {integrity: sha512-Smvy9mguEMtX0lupDLTPshXUzAHeOhgscr1bhGNjeCCLD1sd8rIjBvWV19Wtra0BL1zTuU2EPOHjR/4k8WoyDg==}
+    cpu: [s390x]
     os: [linux]
     hasBin: true
 
@@ -1468,16 +1549,33 @@ packages:
     os: [linux]
     hasBin: true
 
+  '@bytecodealliance/wizer-linux-x64@3.0.1':
+    resolution: {integrity: sha512-uUue78xl7iwndsGgTsagHLTLyLBVHhwzuywiwHt1xw8y0X0O8REKRLBoB7+LdM+pttDPdFtKJgbTFL4UPAA7Yw==}
+    cpu: [x64]
+    os: [linux]
+    hasBin: true
+
   '@bytecodealliance/wizer-linux-x64@7.0.5':
     resolution: {integrity: sha512-lxMb25jLd6n+hhjPhlqRBnBdGRumKkcEavqJ3p4OAtjr6pEPdbSfSVmYDt9LnvtqmqQSnUCtFRRr5J2BmQ3SkQ==}
     cpu: [x64]
     os: [linux]
     hasBin: true
 
+  '@bytecodealliance/wizer-win32-x64@3.0.1':
+    resolution: {integrity: sha512-ycd38sx1UTZpHZwh8IfH/4N3n0OQUB8awxkUSLXf9PolEd088YbxoPB3noHy4E+L2oYN7KZMrg9517pX0z2RhQ==}
+    cpu: [x64]
+    os: [win32]
+    hasBin: true
+
   '@bytecodealliance/wizer-win32-x64@7.0.5':
     resolution: {integrity: sha512-eUY9a82HR20qIfyEffWdJZj7k4GH2wGaZpr70dinDy8Q648LeQayL0Z6FW5nApoezjy+CIBj0Mv+rHUASV9Jzw==}
     cpu: [x64]
     os: [win32]
+    hasBin: true
+
+  '@bytecodealliance/wizer@3.0.1':
+    resolution: {integrity: sha512-f0NBiBHCNBkbFHTPRbA7aKf/t4KyNhi2KvSqw3QzCgi8wFF/uLZ0dhejj93rbiKO/iwWbmU7v9K3SVkW81mcjQ==}
+    engines: {node: '>=16'}
     hasBin: true
 
   '@bytecodealliance/wizer@7.0.5':
@@ -1916,6 +2014,11 @@ packages:
 
   '@formatjs/intl-localematcher@0.6.1':
     resolution: {integrity: sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==}
+
+  '@gcoredev/fastedge-sdk-js@1.2.2':
+    resolution: {integrity: sha512-6O8e+I0dpUTeS9chS+2n3C6GbNpn/HOhnSan4jbuPSZjH7z47qLZRtjy7efUQlLJKZKLHWX1KGvq6Jx65uYx6g==}
+    engines: {node: 18 - 23, npm: ^8 || ^9 || ^10}
+    hasBin: true
 
   '@hono/mcp@0.1.1':
     resolution: {integrity: sha512-2iQ4xBKfQdBBJP3V1/XCVyxQZeWWnxJG+5ytu9/Xuwwje3D70fm9ws0VV536rZ3CKWrnZZ/X+xeJ7FwR3ErVbw==}
@@ -3546,6 +3649,10 @@ packages:
     resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
     engines: {node: '>=12'}
 
+  ansi-styles@3.2.1:
+    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
+    engines: {node: '>=4'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -3553,6 +3660,9 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -3786,6 +3896,10 @@ packages:
     resolution: {integrity: sha512-T2VJbcDuZQ0Tb2EWwSotMPJjgpy1/tGee1BTpUNsGZ/qgNjV2t7Mvu+d4600U564nbLesN1x2dPL+xii174Ekg==}
     engines: {node: '>=14.16'}
 
+  chalk@2.4.2:
+    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
+    engines: {node: '>=4'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -3862,9 +3976,15 @@ packages:
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
+  color-convert@1.9.3:
+    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
+
+  color-name@1.1.3:
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -3942,6 +4062,10 @@ packages:
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
+
+  cross-spawn@6.0.6:
+    resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
+    engines: {node: '>=4.8'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -4115,6 +4239,10 @@ packages:
 
   enquirer@2.3.6:
     resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==}
+    engines: {node: '>=8.6'}
+
+  enquirer@2.4.1:
+    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
   error-ex@1.3.2:
@@ -4361,6 +4489,9 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  event-target-polyfill@0.0.4:
+    resolution: {integrity: sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==}
 
   eventsource-parser@3.0.3:
     resolution: {integrity: sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==}
@@ -4661,6 +4792,10 @@ packages:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
 
+  has-flag@3.0.0:
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
+    engines: {node: '>=4'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -4702,6 +4837,9 @@ packages:
   hono@4.8.10:
     resolution: {integrity: sha512-DRMYbR3aFk6YET1FCSAFbgF2cWYTz5j0YAFYPECx9fmrbKBDAYnWU+YCgRTpOaatxMYN6e68U/2IG39zRP4W/A==}
     engines: {node: '>=16.9.0'}
+
+  hosted-git-info@2.8.9:
+    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
 
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
@@ -4974,6 +5112,10 @@ packages:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
+  jsesc@0.5.0:
+    resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
+    hasBin: true
+
   jsesc@3.0.2:
     resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
     engines: {node: '>=6'}
@@ -4986,6 +5128,9 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-parse-better-errors@1.0.2:
+    resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
@@ -5014,6 +5159,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -5100,6 +5249,10 @@ packages:
   lines-and-columns@2.0.3:
     resolution: {integrity: sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  load-json-file@4.0.0:
+    resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
+    engines: {node: '>=4'}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -5213,6 +5366,10 @@ packages:
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
+
+  memorystream@0.3.1:
+    resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
+    engines: {node: '>= 0.10.0'}
 
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
@@ -5447,15 +5604,26 @@ packages:
       sass:
         optional: true
 
+  nice-try@1.0.5:
+    resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
+
   node-machine-id@1.1.12:
     resolution: {integrity: sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==}
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
+  normalize-package-data@2.5.0:
+    resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
+
   npm-package-arg@11.0.1:
     resolution: {integrity: sha512-M7s1BD4NxdAvBKUPqqRW957Xwcl/4Zvo8Aj+ANrzvIPzGJZElrH7Z//rSaec2ORcND6FHHLnZeY8qgTpXDMFQQ==}
     engines: {node: ^16.14.0 || >=18.0.0}
+
+  npm-run-all@4.1.5:
+    resolution: {integrity: sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==}
+    engines: {node: '>= 4'}
+    hasBin: true
 
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -5575,6 +5743,10 @@ packages:
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
+  parse-json@4.0.0:
+    resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
+    engines: {node: '>=4'}
+
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
@@ -5586,6 +5758,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-key@2.0.1:
+    resolution: {integrity: sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==}
+    engines: {node: '>=4'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -5600,6 +5776,10 @@ packages:
   path-to-regexp@8.2.0:
     resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
     engines: {node: '>=16'}
+
+  path-type@3.0.0:
+    resolution: {integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==}
+    engines: {node: '>=4'}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -5621,6 +5801,11 @@ packages:
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
+
+  pidtree@0.3.1:
+    resolution: {integrity: sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==}
+    engines: {node: '>=0.10'}
+    hasBin: true
 
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -5755,6 +5940,10 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -5844,6 +6033,10 @@ packages:
     resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
     engines: {node: '>=0.10.0'}
 
+  read-pkg@3.0.0:
+    resolution: {integrity: sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==}
+    engines: {node: '>=4'}
+
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
@@ -5897,6 +6090,10 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  regexpu-core@5.3.2:
+    resolution: {integrity: sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==}
+    engines: {node: '>=4'}
+
   regexpu-core@6.2.0:
     resolution: {integrity: sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==}
     engines: {node: '>=4'}
@@ -5906,6 +6103,10 @@ packages:
 
   regjsparser@0.12.0:
     resolution: {integrity: sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==}
+    hasBin: true
+
+  regjsparser@0.9.1:
+    resolution: {integrity: sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==}
     hasBin: true
 
   rehype-recma@1.0.0:
@@ -6003,6 +6204,10 @@ packages:
     resolution: {integrity: sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==}
     hasBin: true
 
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -6043,13 +6248,25 @@ packages:
     resolution: {integrity: sha512-eX2IQ6nFohW4DbvHIOLRB3MHFpYqaqvXd3Tp5e/T/dSH83fxaNJQRvDMhASmkNTsNTVF2/OOopzRCt7xokgPfg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
+  shebang-command@1.2.0:
+    resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
+    engines: {node: '>=0.10.0'}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
 
+  shebang-regex@1.0.0:
+    resolution: {integrity: sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==}
+    engines: {node: '>=0.10.0'}
+
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
 
   shiki@3.8.1:
     resolution: {integrity: sha512-+MYIyjwGPCaegbpBeFN9+oOifI8CKiKG3awI/6h3JeT85c//H2wDW/xCJEGuQ5jPqtbboKNqNy+JyX9PYpGwNg==}
@@ -6112,6 +6329,18 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  spdx-correct@3.2.0:
+    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+
+  spdx-license-ids@3.0.21:
+    resolution: {integrity: sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==}
+
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
@@ -6153,6 +6382,10 @@ packages:
 
   string.prototype.matchall@4.0.12:
     resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.padend@3.1.6:
+    resolution: {integrity: sha512-XZpspuSB7vJWhvJc9DLSlrXl1mcA2BdoY5jjnS135ydXqLoqhs96JjDtCkjJEQHvfqZIp9hBuBMgI589peyx9Q==}
     engines: {node: '>= 0.4'}
 
   string.prototype.repeat@1.0.0:
@@ -6224,6 +6457,10 @@ packages:
   supports-color@10.0.0:
     resolution: {integrity: sha512-HRVVSbCCMbj7/kdWF9Q+bbckjBHLtHMEoJWlkmYzzdwhYMkjkOwubLM6t7NbWKjgKamGDrWL1++KrjUO1t9oAQ==}
     engines: {node: '>=18'}
+
+  supports-color@5.5.0:
+    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
+    engines: {node: '>=4'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -6465,6 +6702,9 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  validate-npm-package-license@3.0.4:
+    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -6501,6 +6741,10 @@ packages:
   which-typed-array@1.1.19:
     resolution: {integrity: sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==}
     engines: {node: '>= 0.4'}
+
+  which@1.3.1:
+    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -7315,6 +7559,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/regjsgen@0.8.0': {}
+
   '@babel/runtime@7.28.2': {}
 
   '@babel/template@7.27.2':
@@ -7368,23 +7614,50 @@ snapshots:
       decompress-tar: 4.1.1
       decompress-unzip: 4.0.1
 
+  '@bytecodealliance/wizer-darwin-arm64@3.0.1':
+    optional: true
+
   '@bytecodealliance/wizer-darwin-arm64@7.0.5':
+    optional: true
+
+  '@bytecodealliance/wizer-darwin-x64@3.0.1':
     optional: true
 
   '@bytecodealliance/wizer-darwin-x64@7.0.5':
     optional: true
 
+  '@bytecodealliance/wizer-linux-arm64@3.0.1':
+    optional: true
+
   '@bytecodealliance/wizer-linux-arm64@7.0.5':
+    optional: true
+
+  '@bytecodealliance/wizer-linux-s390x@3.0.1':
     optional: true
 
   '@bytecodealliance/wizer-linux-s390x@7.0.5':
     optional: true
 
+  '@bytecodealliance/wizer-linux-x64@3.0.1':
+    optional: true
+
   '@bytecodealliance/wizer-linux-x64@7.0.5':
+    optional: true
+
+  '@bytecodealliance/wizer-win32-x64@3.0.1':
     optional: true
 
   '@bytecodealliance/wizer-win32-x64@7.0.5':
     optional: true
+
+  '@bytecodealliance/wizer@3.0.1':
+    optionalDependencies:
+      '@bytecodealliance/wizer-darwin-arm64': 3.0.1
+      '@bytecodealliance/wizer-darwin-x64': 3.0.1
+      '@bytecodealliance/wizer-linux-arm64': 3.0.1
+      '@bytecodealliance/wizer-linux-s390x': 3.0.1
+      '@bytecodealliance/wizer-linux-x64': 3.0.1
+      '@bytecodealliance/wizer-win32-x64': 3.0.1
 
   '@bytecodealliance/wizer@7.0.5':
     optionalDependencies:
@@ -7678,6 +7951,21 @@ snapshots:
   '@formatjs/intl-localematcher@0.6.1':
     dependencies:
       tslib: 2.8.1
+
+  '@gcoredev/fastedge-sdk-js@1.2.2':
+    dependencies:
+      '@bytecodealliance/jco': 1.13.0
+      '@bytecodealliance/wizer': 3.0.1
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 5.0.2
+      enquirer: 2.4.1
+      esbuild: 0.25.8
+      event-target-polyfill: 0.0.4
+      magic-string: 0.30.17
+      npm-run-all: 4.1.5
+      prompts: 2.4.2
+      regexpu-core: 5.3.2
 
   '@hono/mcp@0.1.1(@modelcontextprotocol/sdk@1.17.0)(hono@4.8.10)':
     dependencies:
@@ -9129,11 +9417,17 @@ snapshots:
 
   ansi-regex@6.1.0: {}
 
+  ansi-styles@3.2.1:
+    dependencies:
+      color-convert: 1.9.3
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
+
+  arg@5.0.2: {}
 
   argparse@1.0.10:
     dependencies:
@@ -9406,6 +9700,12 @@ snapshots:
     dependencies:
       chalk: 5.4.1
 
+  chalk@2.4.2:
+    dependencies:
+      ansi-styles: 3.2.1
+      escape-string-regexp: 1.0.5
+      supports-color: 5.5.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -9465,9 +9765,15 @@ snapshots:
 
   collapse-white-space@2.1.0: {}
 
+  color-convert@1.9.3:
+    dependencies:
+      color-name: 1.1.3
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
+
+  color-name@1.1.3: {}
 
   color-name@1.1.4: {}
 
@@ -9536,6 +9842,14 @@ snapshots:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.2
+
+  cross-spawn@6.0.6:
+    dependencies:
+      nice-try: 1.0.5
+      path-key: 2.0.1
+      semver: 5.7.2
+      shebang-command: 1.2.0
+      which: 1.3.1
 
   cross-spawn@7.0.6:
     dependencies:
@@ -9708,6 +10022,11 @@ snapshots:
   enquirer@2.3.6:
     dependencies:
       ansi-colors: 4.1.3
+
+  enquirer@2.4.1:
+    dependencies:
+      ansi-colors: 4.1.3
+      strip-ansi: 6.0.1
 
   error-ex@1.3.2:
     dependencies:
@@ -10156,6 +10475,8 @@ snapshots:
 
   etag@1.8.1: {}
 
+  event-target-polyfill@0.0.4: {}
+
   eventsource-parser@3.0.3: {}
 
   eventsource@3.0.7:
@@ -10484,6 +10805,8 @@ snapshots:
 
   has-bigints@1.1.0: {}
 
+  has-flag@3.0.0: {}
+
   has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
@@ -10568,6 +10891,8 @@ snapshots:
       '@types/hast': 3.0.4
 
   hono@4.8.10: {}
+
+  hosted-git-info@2.8.9: {}
 
   hosted-git-info@7.0.2:
     dependencies:
@@ -10816,11 +11141,15 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsesc@0.5.0: {}
+
   jsesc@3.0.2: {}
 
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
+
+  json-parse-better-errors@1.0.2: {}
 
   json-parse-even-better-errors@2.3.1: {}
 
@@ -10846,6 +11175,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kleur@3.0.3: {}
 
   kleur@4.1.5: {}
 
@@ -10908,6 +11239,13 @@ snapshots:
   lines-and-columns@1.2.4: {}
 
   lines-and-columns@2.0.3: {}
+
+  load-json-file@4.0.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      parse-json: 4.0.0
+      pify: 3.0.0
+      strip-bom: 3.0.0
 
   locate-path@6.0.0:
     dependencies:
@@ -11125,6 +11463,8 @@ snapshots:
       '@types/mdast': 4.0.4
 
   media-typer@1.1.0: {}
+
+  memorystream@0.3.1: {}
 
   merge-descriptors@2.0.0: {}
 
@@ -11501,9 +11841,18 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  nice-try@1.0.5: {}
+
   node-machine-id@1.1.12: {}
 
   node-releases@2.0.19: {}
+
+  normalize-package-data@2.5.0:
+    dependencies:
+      hosted-git-info: 2.8.9
+      resolve: 1.22.10
+      semver: 5.7.2
+      validate-npm-package-license: 3.0.4
 
   npm-package-arg@11.0.1:
     dependencies:
@@ -11511,6 +11860,18 @@ snapshots:
       proc-log: 3.0.0
       semver: 7.7.2
       validate-npm-package-name: 5.0.1
+
+  npm-run-all@4.1.5:
+    dependencies:
+      ansi-styles: 3.2.1
+      chalk: 2.4.2
+      cross-spawn: 6.0.6
+      memorystream: 0.3.1
+      minimatch: 3.1.2
+      pidtree: 0.3.1
+      read-pkg: 3.0.0
+      shell-quote: 1.8.3
+      string.prototype.padend: 3.1.6
 
   npm-run-path@4.0.1:
     dependencies:
@@ -11741,6 +12102,11 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse-json@4.0.0:
+    dependencies:
+      error-ex: 1.3.2
+      json-parse-better-errors: 1.0.2
+
   parse-json@5.2.0:
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -11752,6 +12118,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-key@2.0.1: {}
+
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
@@ -11759,6 +12127,10 @@ snapshots:
   path-to-regexp@6.3.0: {}
 
   path-to-regexp@8.2.0: {}
+
+  path-type@3.0.0:
+    dependencies:
+      pify: 3.0.0
 
   path-type@4.0.0: {}
 
@@ -11771,6 +12143,8 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
+
+  pidtree@0.3.1: {}
 
   pify@2.3.0: {}
 
@@ -11831,6 +12205,11 @@ snapshots:
   proc-log@3.0.0: {}
 
   process-nextick-args@2.0.1: {}
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
 
   prop-types@15.8.1:
     dependencies:
@@ -11912,6 +12291,12 @@ snapshots:
       '@types/react': 19.1.9
 
   react@19.1.1: {}
+
+  read-pkg@3.0.0:
+    dependencies:
+      load-json-file: 4.0.0
+      normalize-package-data: 2.5.0
+      path-type: 3.0.0
 
   readable-stream@2.3.8:
     dependencies:
@@ -11998,6 +12383,15 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  regexpu-core@5.3.2:
+    dependencies:
+      '@babel/regjsgen': 0.8.0
+      regenerate: 1.4.2
+      regenerate-unicode-properties: 10.2.0
+      regjsparser: 0.9.1
+      unicode-match-property-ecmascript: 2.0.0
+      unicode-match-property-value-ecmascript: 2.2.0
+
   regexpu-core@6.2.0:
     dependencies:
       regenerate: 1.4.2
@@ -12012,6 +12406,10 @@ snapshots:
   regjsparser@0.12.0:
     dependencies:
       jsesc: 3.0.2
+
+  regjsparser@0.9.1:
+    dependencies:
+      jsesc: 0.5.0
 
   rehype-recma@1.0.0:
     dependencies:
@@ -12152,6 +12550,8 @@ snapshots:
     dependencies:
       commander: 2.20.3
 
+  semver@5.7.2: {}
+
   semver@6.3.1: {}
 
   semver@7.7.2: {}
@@ -12261,11 +12661,19 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.3
     optional: true
 
+  shebang-command@1.2.0:
+    dependencies:
+      shebang-regex: 1.0.0
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
+  shebang-regex@1.0.0: {}
+
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.8.3: {}
 
   shiki@3.8.1:
     dependencies:
@@ -12346,6 +12754,20 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  spdx-correct@3.2.0:
+    dependencies:
+      spdx-expression-parse: 3.0.1
+      spdx-license-ids: 3.0.21
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@3.0.1:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.21
+
+  spdx-license-ids@3.0.21: {}
+
   sprintf-js@1.0.3: {}
 
   stable-hash-x@0.2.0: {}
@@ -12396,6 +12818,13 @@ snapshots:
       regexp.prototype.flags: 1.5.4
       set-function-name: 2.0.2
       side-channel: 1.1.0
+
+  string.prototype.padend@3.1.6:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.24.0
+      es-object-atoms: 1.1.1
 
   string.prototype.repeat@1.0.0:
     dependencies:
@@ -12474,6 +12903,10 @@ snapshots:
       '@babel/core': 7.28.0
 
   supports-color@10.0.0: {}
+
+  supports-color@5.5.0:
+    dependencies:
+      has-flag: 3.0.0
 
   supports-color@7.2.0:
     dependencies:
@@ -12771,6 +13204,11 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  validate-npm-package-license@3.0.4:
+    dependencies:
+      spdx-correct: 3.2.0
+      spdx-expression-parse: 3.0.1
+
   validate-npm-package-name@5.0.1: {}
 
   validate-npm-package-name@6.0.2: {}
@@ -12831,6 +13269,10 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-tostringtag: 1.0.2
+
+  which@1.3.1:
+    dependencies:
+      isexe: 2.0.0
 
   which@2.0.2:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,9 @@
       "path": "./apps/example-fastly-ts"
     },
     {
+      "path": "./apps/example-gcore-ts"
+    },
+    {
       "path": "./apps/example-netlify-ts"
     },
     {
@@ -60,6 +63,9 @@
     },
     {
       "path": "./libs/modelfetch-fastly"
+    },
+    {
+      "path": "./libs/modelfetch-gcore"
     },
     {
       "path": "./libs/modelfetch-netlify"


### PR DESCRIPTION
## Summary
- Add @modelfetch/gcore package for Gcore FastEdge runtime support
- Include JavaScript and TypeScript example applications
- Add deployment executor and comprehensive documentation

## Test plan
- [ ] Build and typecheck pass
- [ ] Lint checks pass
- [ ] Example applications work correctly
- [ ] Documentation is accurate and complete

🤖 Generated with Claude Code