### PR TITLE
Fix Gcore deployment URL output to include /mcp endpoint

### DIFF
--- a/.nx/version-plans/fix-gcore-deployment-url-output.md
+++ b/.nx/version-plans/fix-gcore-deployment-url-output.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Fix Gcore deployment URL output to include /mcp endpoint and update documentation

--- a/apps/example-gcore-js/README.md
+++ b/apps/example-gcore-js/README.md
@@ -23,7 +23,7 @@ In a separate terminal, run the MCP Inspector to test your server:
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at the URL shown in the output.
+Then, connect to your server at the URL shown in the output (ends with `/mcp`).
 
 ## Project Structure
 

--- a/apps/example-gcore-ts/README.md
+++ b/apps/example-gcore-ts/README.md
@@ -23,7 +23,7 @@ In a separate terminal, run the MCP Inspector to test your server:
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at the URL shown in the output.
+Then, connect to your server at the URL shown in the output (ends with `/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/gcore-js/README.md.template
+++ b/libs/create-modelfetch/templates/gcore-js/README.md.template
@@ -22,7 +22,7 @@ In a separate terminal, run the MCP Inspector to test your server:
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at the URL shown in the output.
+Then, connect to your server at the URL shown in the output (ends with `/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/gcore-js/deploy.js.template
+++ b/libs/create-modelfetch/templates/gcore-js/deploy.js.template
@@ -75,4 +75,4 @@ if (!deployResponse.ok) {
   );
 }
 
-console.log((await deployResponse.json()).url);
+console.log((await deployResponse.json()).url + "/mcp");

--- a/libs/create-modelfetch/templates/gcore-ts/README.md.template
+++ b/libs/create-modelfetch/templates/gcore-ts/README.md.template
@@ -22,7 +22,7 @@ In a separate terminal, run the MCP Inspector to test your server:
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at the URL shown in the output.
+Then, connect to your server at the URL shown in the output (ends with `/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/gcore-ts/deploy.js.template
+++ b/libs/create-modelfetch/templates/gcore-ts/deploy.js.template
@@ -75,4 +75,4 @@ if (!deployResponse.ok) {
   );
 }
 
-console.log((await deployResponse.json()).url);
+console.log((await deployResponse.json()).url + "/mcp");

--- a/libs/nx-10x/src/executors/deploy-gcore-fastedge/index.ts
+++ b/libs/nx-10x/src/executors/deploy-gcore-fastedge/index.ts
@@ -80,6 +80,6 @@ export default async function deployGcoreFastedgeExecutor(
   const createOrUpdateResult = (await createOrUpdateResponse.json()) as {
     url: string;
   };
-  logger.info(`URL: ${createOrUpdateResult.url}`);
+  logger.info(`URL: ${createOrUpdateResult.url}/mcp`);
   return { success: true };
 }


### PR DESCRIPTION
## Summary
- Fixed deployment scripts to append `/mcp` to the deployment URL output
- Updated documentation to clarify that the deployment URL ends with `/mcp`
- Ensures users connect to the correct endpoint when testing with MCP Inspector

## Test plan
- [x] Verify deployment scripts output URLs with `/mcp` suffix
- [ ] Test deployment with example Gcore applications
- [ ] Confirm MCP Inspector connects successfully to the `/mcp` endpoint

🤖 Generated with [Claude Code](https://claude.ai/code)