### PR TITLE
Add JSDoc documentation to @modelfetch/core

### DIFF
--- a/.nx/version-plans/add-modelfetch-core-jsdoc.md
+++ b/.nx/version-plans/add-modelfetch-core-jsdoc.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Add comprehensive JSDoc documentation to @modelfetch/core module and update nx-10x README formatting

--- a/libs/modelfetch-core/src/index.ts
+++ b/libs/modelfetch-core/src/index.ts
@@ -1,25 +1,80 @@
+/**
+ * Core utilities for MCP servers built with ModelFetch.
+ *
+ * This module provides the foundational components for creating MCP servers that can be deployed
+ * across various JavaScript/TypeScript runtimes.
+ *
+ * @example
+ * ```ts
+ * import { createApp } from "@modelfetch/core";
+ * import server from "./server";
+ *
+ * // Basic usage
+ * const basicApp = createApp(server);
+ *
+ * // Advanced usage
+ * const advancedApp = createApp({
+ *   server,
+ *   base: "/api",
+ *   path: "/mcp",
+ *   middleware: [authMiddleware, loggingMiddleware],
+ *   pre: (app) => {
+ *     // Configure routes before MCP endpoint
+ *     app.get("/health", (c) => c.text("OK"));
+ *   },
+ *   post: (app) => {
+ *     // Configure routes after MCP endpoint
+ *     app.notFound((c) => c.text("Not found", 404));
+ *   }
+ * });
+ * ```
+ *
+ * @module
+ */
+
 import type { MiddlewareHandler } from "hono";
 
 import { StreamableHTTPTransport } from "@hono/mcp";
 import { Hono } from "hono";
 
+/**
+ * MCP server application.
+ */
 export type App = Hono;
 
+/**
+ * MCP server implementation.
+ */
 export interface Server {
   connect: (transport: StreamableHTTPTransport) => Promise<void>;
 }
 
+/**
+ * MCP server configuration.
+ */
 export interface Config {
+  /** MCP server implementation. */
   server: Server;
+  /** Base path for all routes. */
   base?: string;
+  /** Custom path for the MCP endpoint (defaults to "/mcp"). */
   path?: string;
+  /** Middleware to apply to the MCP endpoint. */
   middleware?: MiddlewareHandler[];
+  /** Hook to configure routes before the MCP endpoint. */
   pre?: (app: Hono) => void;
+  /** Hook to configure routes after the MCP endpoint. */
   post?: (app: Hono) => void;
 }
 
+/**
+ * MCP server implementation or configuration.
+ */
 export type ServerOrConfig = Server | Config;
 
+/**
+ * Creates an MCP server application from an MCP server implementation or configuration.
+ */
 export function createApp(arg: ServerOrConfig): App {
   const config: Config = "connect" in arg ? { server: arg } : arg;
 

--- a/libs/nx-10x/README.md
+++ b/libs/nx-10x/README.md
@@ -5,9 +5,7 @@
 
 ## Usage
 
-### Configuration
-
-Add to `nx.json`:
+### `nx.json`
 
 ```json
 {
@@ -25,7 +23,6 @@ Add to `nx.json`:
 ### Generators
 
 ```bash
-# Create a library
 pnpm exec nx g nx-10x:create-library
 ```
 
@@ -34,11 +31,9 @@ pnpm exec nx g nx-10x:create-library
 ```json
 {
   "targets": {
-    // Prepare for release publishing
     "prepare-release-publish": {
       "executor": "nx-10x:prepare-release-publish"
     },
-    // Deploy a Gcore FastEdge application
     "deploy-gcore-fastedge": {
       "executor": "nx-10x:deploy-gcore-fastedge"
     }


### PR DESCRIPTION
## Summary
- Added comprehensive module-level JSDoc documentation to @modelfetch/core
- Added JSDoc comments for all exported types and functions
- Minor formatting improvements to nx-10x README

## Test plan
- [x] Run `pnpm -w format`
- [x] Run `pnpm exec nx run-many -t typecheck`
- [x] Run `pnpm exec nx run-many -t lint --args=--fix`
- [x] Verify documentation renders correctly in JSR and other documentation tools

🤖 Generated with [Claude Code](https://claude.ai/code)