### PR TITLE
Improve dynamic path support and documentation consistency

### DIFF
--- a/.nx/version-plans/support-dynamic-paths.md
+++ b/.nx/version-plans/support-dynamic-paths.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Support dynamic base and MCP paths with improved documentation consistency across all runtime environments

--- a/apps/example-aws-lambda-js/README.md
+++ b/apps/example-aws-lambda-js/README.md
@@ -7,31 +7,29 @@
 
 ### Deploying the MCP server
 
-Deploy the MCP server to AWS Lambda:
+Deploy your MCP server to AWS Lambda:
 
 ```bash
 pnpm exec nx deploy example-aws-lambda-js
 ```
 
-After deployment, the CDK output will show your MCP server URL.
+### Destroying the MCP server
+
+Destroy your MCP server and all its AWS resources:
+
+```bash
+pnpm exec nx destroy example-aws-lambda-js
+```
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at the URL shown in the CDK output (ends with `/mcp`).
-
-### Deleting the MCP server
-
-To delete the MCP server and all its AWS resources:
-
-```bash
-pnpm exec nx destroy example-aws-lambda-js
-```
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `<mcp-server-url>/mcp`).
 
 ## Project Structure
 

--- a/apps/example-aws-lambda-js/cdk.js
+++ b/apps/example-aws-lambda-js/cdk.js
@@ -21,7 +21,7 @@ class ModelFetchExampleAWSLambdaJavaScriptStack extends Stack {
       invokeMode: InvokeMode.RESPONSE_STREAM,
     });
 
-    new CfnOutput(this, "McpServerUrl", { value: `${functionUrl.url}mcp` });
+    new CfnOutput(this, "McpServerUrl", { value: functionUrl.url });
   }
 }
 

--- a/apps/example-aws-lambda-ts/README.md
+++ b/apps/example-aws-lambda-ts/README.md
@@ -7,31 +7,29 @@
 
 ### Deploying the MCP server
 
-Deploy the MCP server to AWS Lambda:
+Deploy your MCP server to AWS Lambda:
 
 ```bash
 pnpm exec nx deploy example-aws-lambda-ts
 ```
 
-After deployment, the CDK output will show your MCP server URL.
+### Destroying the MCP server
+
+Destroy your MCP server and all its AWS resources:
+
+```bash
+pnpm exec nx destroy example-aws-lambda-ts
+```
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at the URL shown in the CDK output (ends with `/mcp`).
-
-### Deleting the MCP server
-
-To delete the MCP server and all its AWS resources:
-
-```bash
-pnpm exec nx destroy example-aws-lambda-ts
-```
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `<mcp-server-url>/mcp`).
 
 ## Project Structure
 

--- a/apps/example-aws-lambda-ts/cdk.js
+++ b/apps/example-aws-lambda-ts/cdk.js
@@ -21,7 +21,7 @@ class ModelFetchExampleAWSLambdaTypeScriptStack extends Stack {
       invokeMode: InvokeMode.RESPONSE_STREAM,
     });
 
-    new CfnOutput(this, "McpServerUrl", { value: `${functionUrl.url}mcp` });
+    new CfnOutput(this, "McpServerUrl", { value: functionUrl.url });
   }
 }
 

--- a/apps/example-azure-functions-js/README.md
+++ b/apps/example-azure-functions-js/README.md
@@ -7,7 +7,7 @@
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 pnpm exec nx start example-azure-functions-js
@@ -15,13 +15,13 @@ pnpm exec nx start example-azure-functions-js
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:7071/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:7071/mcp`).
 
 ## Project Structure
 

--- a/apps/example-azure-functions-ts/README.md
+++ b/apps/example-azure-functions-ts/README.md
@@ -7,7 +7,7 @@
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 pnpm exec nx start example-azure-functions-ts
@@ -15,13 +15,13 @@ pnpm exec nx start example-azure-functions-ts
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:7071/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:7071/mcp`).
 
 ## Project Structure
 

--- a/apps/example-bun-js/README.md
+++ b/apps/example-bun-js/README.md
@@ -7,7 +7,7 @@
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 pnpm exec nx start example-bun-js
@@ -15,13 +15,13 @@ pnpm exec nx start example-bun-js
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:3000/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:3000/mcp`).
 
 ## Project Structure
 

--- a/apps/example-bun-ts/README.md
+++ b/apps/example-bun-ts/README.md
@@ -7,7 +7,7 @@
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 pnpm exec nx start example-bun-ts
@@ -15,13 +15,13 @@ pnpm exec nx start example-bun-ts
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:3000/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:3000/mcp`).
 
 ## Project Structure
 

--- a/apps/example-cloudflare-js/README.md
+++ b/apps/example-cloudflare-js/README.md
@@ -7,7 +7,7 @@
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 pnpm exec nx dev example-cloudflare-js
@@ -15,31 +15,29 @@ pnpm exec nx dev example-cloudflare-js
 
 ### Deploying the MCP server
 
-Deploy the MCP server to Cloudflare:
+Deploy your MCP server to Cloudflare:
 
 ```bash
 pnpm exec nx deploy example-cloudflare-js
 ```
 
-After deployment, the output will show your MCP server URL.
+### Deleting the MCP server
+
+Delete your MCP server and all its Cloudflare resources:
+
+```bash
+pnpm exec nx delete example-cloudflare-js
+```
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:8787/mcp` (or the URL shown in the output).
-
-### Deleting the MCP server
-
-To delete the MCP server and all its Cloudflare resources:
-
-```bash
-pnpm exec nx delete example-cloudflare-js
-```
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:8787/mcp`).
 
 ## Project Structure
 

--- a/apps/example-cloudflare-ts/README.md
+++ b/apps/example-cloudflare-ts/README.md
@@ -7,7 +7,7 @@
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 pnpm exec nx dev example-cloudflare-ts
@@ -15,31 +15,29 @@ pnpm exec nx dev example-cloudflare-ts
 
 ### Deploying the MCP server
 
-Deploy the MCP server to Cloudflare:
+Deploy your MCP server to Cloudflare:
 
 ```bash
 pnpm exec nx deploy example-cloudflare-ts
 ```
 
-After deployment, the output will show your MCP server URL.
+### Deleting the MCP server
+
+Delete your MCP server and all its Cloudflare resources:
+
+```bash
+pnpm exec nx delete example-cloudflare-ts
+```
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:8787/mcp` (or the URL shown in the output).
-
-### Deleting the MCP server
-
-To delete the MCP server and all its Cloudflare resources:
-
-```bash
-pnpm exec nx delete example-cloudflare-ts
-```
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:8787/mcp`).
 
 ## Project Structure
 

--- a/apps/example-deno-js/README.md
+++ b/apps/example-deno-js/README.md
@@ -7,7 +7,7 @@
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 pnpm exec nx start example-deno-js
@@ -15,13 +15,13 @@ pnpm exec nx start example-deno-js
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:8000/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:8000/mcp`).
 
 ## Project Structure
 

--- a/apps/example-deno-ts/README.md
+++ b/apps/example-deno-ts/README.md
@@ -7,7 +7,7 @@
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 pnpm exec nx start example-deno-ts
@@ -15,13 +15,13 @@ pnpm exec nx start example-deno-ts
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:8000/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:8000/mcp`).
 
 ## Project Structure
 

--- a/apps/example-fastly-js/README.md
+++ b/apps/example-fastly-js/README.md
@@ -7,7 +7,7 @@
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 pnpm exec nx dev example-fastly-js
@@ -15,23 +15,21 @@ pnpm exec nx dev example-fastly-js
 
 ### Deploying the MCP server
 
-Deploy the MCP server to Fastly:
+Deploy your MCP server to Fastly:
 
 ```bash
 pnpm exec nx deploy example-fastly-js
 ```
 
-After deployment, the output will show your MCP server URL.
-
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:7676/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:7676/mcp`).
 
 ## Project Structure
 

--- a/apps/example-fastly-ts/README.md
+++ b/apps/example-fastly-ts/README.md
@@ -7,7 +7,7 @@
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 pnpm exec nx dev example-fastly-ts
@@ -15,23 +15,21 @@ pnpm exec nx dev example-fastly-ts
 
 ### Deploying the MCP server
 
-Deploy the MCP server to Fastly:
+Deploy your MCP server to Fastly:
 
 ```bash
 pnpm exec nx deploy example-fastly-ts
 ```
 
-After deployment, the output will show your MCP server URL.
-
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:7676/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:7676/mcp`).
 
 ## Project Structure
 

--- a/apps/example-gcore-js/README.md
+++ b/apps/example-gcore-js/README.md
@@ -7,23 +7,21 @@
 
 ### Deploying the MCP server
 
-Deploy the MCP server to Gcore:
+Deploy your MCP server to Gcore:
 
 ```bash
 pnpm exec nx deploy example-gcore-js
 ```
 
-After deployment, the output will show your MCP server URL.
-
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at the URL shown in the output (ends with `/mcp`).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `<mcp-server-url>/mcp`).
 
 ## Project Structure
 

--- a/apps/example-gcore-ts/README.md
+++ b/apps/example-gcore-ts/README.md
@@ -7,23 +7,21 @@
 
 ### Deploying the MCP server
 
-Deploy the MCP server to Gcore:
+Deploy your MCP server to Gcore:
 
 ```bash
 pnpm exec nx deploy example-gcore-ts
 ```
 
-After deployment, the output will show your MCP server URL.
-
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at the URL shown in the output (ends with `/mcp`).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `<mcp-server-url>/mcp`).
 
 ## Project Structure
 

--- a/apps/example-netlify-js/README.md
+++ b/apps/example-netlify-js/README.md
@@ -7,7 +7,7 @@
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 pnpm exec nx dev example-netlify-js
@@ -15,13 +15,13 @@ pnpm exec nx dev example-netlify-js
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:8888/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:8888/mcp`).
 
 ## Project Structure
 

--- a/apps/example-netlify-ts/README.md
+++ b/apps/example-netlify-ts/README.md
@@ -7,7 +7,7 @@
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 pnpm exec nx dev example-netlify-ts
@@ -15,13 +15,13 @@ pnpm exec nx dev example-netlify-ts
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:8888/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:8888/mcp`).
 
 ## Project Structure
 

--- a/apps/example-next-js/README.md
+++ b/apps/example-next-js/README.md
@@ -7,7 +7,7 @@
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 pnpm exec nx dev example-next-js
@@ -15,13 +15,13 @@ pnpm exec nx dev example-next-js
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:3000/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:3000/mcp`).
 
 ## Project Structure
 

--- a/apps/example-next-ts/README.md
+++ b/apps/example-next-ts/README.md
@@ -7,7 +7,7 @@
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 pnpm exec nx dev example-next-ts
@@ -15,13 +15,13 @@ pnpm exec nx dev example-next-ts
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:3000/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:3000/mcp`).
 
 ## Project Structure
 

--- a/apps/example-node-js/README.md
+++ b/apps/example-node-js/README.md
@@ -7,7 +7,7 @@
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 pnpm exec nx start example-node-js
@@ -15,13 +15,13 @@ pnpm exec nx start example-node-js
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:3000/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:3000/mcp`).
 
 ## Project Structure
 

--- a/apps/example-node-ts/README.md
+++ b/apps/example-node-ts/README.md
@@ -7,7 +7,7 @@
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 pnpm exec nx start example-node-ts
@@ -15,13 +15,13 @@ pnpm exec nx start example-node-ts
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:3000/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:3000/mcp`).
 
 ## Project Structure
 

--- a/apps/example-supabase-js/README.md
+++ b/apps/example-supabase-js/README.md
@@ -7,7 +7,7 @@
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 pnpm exec nx start example-supabase-js
@@ -23,13 +23,13 @@ pnpm exec nx stop example-supabase-js
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:54321/functions/v1/mcp-server/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:54321/functions/v1/mcp-server/mcp`).
 
 ## Project Structure
 

--- a/apps/example-supabase-ts/README.md
+++ b/apps/example-supabase-ts/README.md
@@ -7,7 +7,7 @@
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 pnpm exec nx start example-supabase-ts
@@ -23,13 +23,13 @@ pnpm exec nx stop example-supabase-ts
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:54321/functions/v1/mcp-server/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:54321/functions/v1/mcp-server/mcp`).
 
 ## Project Structure
 

--- a/apps/example-vercel-js/README.md
+++ b/apps/example-vercel-js/README.md
@@ -7,7 +7,7 @@
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 pnpm exec nx dev example-vercel-js
@@ -15,13 +15,13 @@ pnpm exec nx dev example-vercel-js
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:3000/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:3000/mcp`).
 
 ## Project Structure
 

--- a/apps/example-vercel-ts/README.md
+++ b/apps/example-vercel-ts/README.md
@@ -7,7 +7,7 @@
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 pnpm exec nx dev example-vercel-ts
@@ -15,13 +15,13 @@ pnpm exec nx dev example-vercel-ts
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:3000/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:3000/mcp`).
 
 ## Project Structure
 

--- a/apps/modelfetch-website/mdx/middleware.mdx
+++ b/apps/modelfetch-website/mdx/middleware.mdx
@@ -17,23 +17,25 @@ import { bearerAuth } from "hono/bearer-auth";
 import { logger } from "hono/logger";
 
 handle({
-  server: myMcpServer,
+  server: mcpServer,
   middleware: [logger(), bearerAuth({ token: "secret-token" })],
 });
 ```
 
 ### Using Pre/Post Hooks
 
-For more control, use the synchronous `pre` and `post` hooks to configure the Hono app:
+For more control, use the `pre` and `post` hooks to configure the Hono app:
 
 ```typescript
+const mcpPath = "/mcp";
+
 handle({
-  server: myMcpServer,
+  server: mcpServer,
+  path: mcpPath,
   pre: (app) => {
     // Configure middleware before MCP routes
     app.use("*", logger());
-    app.use("/mcp/*", bearerAuth({ token: "secret" }));
-
+    app.use(`${mcpPath}/*`, bearerAuth({ token: "secret" }));
     // Add error handling
     app.onError((err, c) => {
       console.error("Error:", err);
@@ -57,16 +59,14 @@ import { createMiddleware } from "hono/factory";
 
 const apiKeyAuth = createMiddleware(async (c, next) => {
   const apiKey = c.req.header("X-API-Key");
-
   if (!apiKey || apiKey !== process.env.API_KEY) {
     return c.json({ error: "Invalid API key" }, 401);
   }
-
   await next();
 });
 
 handle({
-  server: myMcpServer,
+  server: mcpServer,
   middleware: [apiKeyAuth],
 });
 ```
@@ -74,12 +74,18 @@ handle({
 ### Request Logging
 
 ```typescript
+import { createMiddleware } from "hono/factory";
+
 const requestLogger = createMiddleware(async (c, next) => {
   const start = Date.now();
   await next();
   const ms = Date.now() - start;
-
   console.log(`${c.req.method} ${c.req.path} - ${c.res.status} ${ms}ms`);
+});
+
+handle({
+  server: mcpServer,
+  middleware: [requestLogger],
 });
 ```
 
@@ -88,11 +94,14 @@ const requestLogger = createMiddleware(async (c, next) => {
 ```typescript
 import { cors } from "hono/cors";
 
+const mcpPath = "/mcp";
+
 handle({
-  server: myMcpServer,
+  server: mcpServer,
+  path: mcpPath,
   pre: (app) => {
     app.use(
-      "/mcp/*",
+      `${mcpPath}/*`,
       cors({
         origin: ["https://app.example.com"],
         allowHeaders: ["X-API-Key", "Content-Type"],
@@ -109,11 +118,14 @@ handle({
 ```typescript
 import { rateLimiter } from "hono/rate-limiter";
 
+const mcpPath = "/mcp";
+
 handle({
-  server: myMcpServer,
+  server: mcpServer,
+  path: mcpPath,
   pre: (app) => {
     app.use(
-      "/mcp/*",
+      `${mcpPath}/*`,
       rateLimiter({
         windowMs: 15 * 60 * 1000, // 15 minutes
         limit: 100, // 100 requests per window

--- a/libs/create-modelfetch/templates/aws-lambda-js/README.md.template
+++ b/libs/create-modelfetch/templates/aws-lambda-js/README.md.template
@@ -12,25 +12,23 @@ Deploy your MCP server to AWS Lambda:
 <%= packageManager %> run deploy
 ```
 
-After deployment, the CDK output will show your MCP server URL.
+### Destroying the MCP server
+
+Destroy your MCP server and all its AWS resources:
+
+```bash
+<%= packageManager %> run destroy
+```
 
 ### Test with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at the URL shown in the CDK output (ends with `/mcp`).
-
-### Deleting the MCP server
-
-To delete the MCP server and all its AWS resources:
-
-```bash
-<%= packageManager %> run destroy
-```
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `<mcp-server-url>/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/aws-lambda-js/cdk.js.template
+++ b/libs/create-modelfetch/templates/aws-lambda-js/cdk.js.template
@@ -17,7 +17,7 @@ class <%= awsCdkStack %> extends Stack {
       invokeMode: InvokeMode.RESPONSE_STREAM,
     });
 
-    new CfnOutput(this, "McpServerUrl", { value: `${functionUrl.url}mcp` });
+    new CfnOutput(this, "McpServerUrl", { value: functionUrl.url });
   }
 }
 

--- a/libs/create-modelfetch/templates/aws-lambda-ts/README.md.template
+++ b/libs/create-modelfetch/templates/aws-lambda-ts/README.md.template
@@ -12,25 +12,23 @@ Deploy your MCP server to AWS Lambda:
 <%= packageManager %> run deploy
 ```
 
-After deployment, the CDK output will show your MCP server URL.
+### Destroying the MCP server
+
+Destroy your MCP server and all its AWS resources:
+
+```bash
+<%= packageManager %> run destroy
+```
 
 ### Test with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at the URL shown in the CDK output (ends with `/mcp`).
-
-### Deleting the MCP server
-
-To delete the MCP server and all its AWS resources:
-
-```bash
-<%= packageManager %> run destroy
-```
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `<mcp-server-url>/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/aws-lambda-ts/cdk.js.template
+++ b/libs/create-modelfetch/templates/aws-lambda-ts/cdk.js.template
@@ -17,7 +17,7 @@ class <%= awsCdkStack %> extends Stack {
       invokeMode: InvokeMode.RESPONSE_STREAM,
     });
 
-    new CfnOutput(this, "McpServerUrl", { value: `${functionUrl.url}mcp` });
+    new CfnOutput(this, "McpServerUrl", { value: functionUrl.url });
   }
 }
 

--- a/libs/create-modelfetch/templates/azure-functions-js/README.md.template
+++ b/libs/create-modelfetch/templates/azure-functions-js/README.md.template
@@ -6,7 +6,7 @@ An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 <%= packageManager %> start
@@ -14,13 +14,13 @@ Start the MCP server:
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:7071/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:7071/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/azure-functions-ts/README.md.template
+++ b/libs/create-modelfetch/templates/azure-functions-ts/README.md.template
@@ -6,7 +6,7 @@ An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 <%= packageManager %> start
@@ -14,13 +14,13 @@ Start the MCP server:
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:7071/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:7071/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/bun-js/README.md.template
+++ b/libs/create-modelfetch/templates/bun-js/README.md.template
@@ -6,7 +6,7 @@ An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 bun start
@@ -14,13 +14,13 @@ bun start
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:3000/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:3000/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/bun-ts/README.md.template
+++ b/libs/create-modelfetch/templates/bun-ts/README.md.template
@@ -6,7 +6,7 @@ An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 bun start
@@ -14,13 +14,13 @@ bun start
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:3000/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:3000/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/cloudflare-js/README.md.template
+++ b/libs/create-modelfetch/templates/cloudflare-js/README.md.template
@@ -6,7 +6,7 @@ An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 <%= packageManager %> run dev
@@ -14,31 +14,29 @@ Start the MCP server:
 
 ### Deploying the MCP server
 
-Deploy the MCP server to Cloudflare:
+Deploy your MCP server to Cloudflare:
 
 ```bash
 <%= packageManager %> run deploy
 ```
 
-After deployment, the output will show your MCP server URL.
+### Deleting the MCP server
+
+Delete your MCP server and all its Cloudflare resources:
+
+```bash
+<%= packageManager %> run delete
+```
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:8787/mcp` (or the URL shown in the output).
-
-### Deleting the MCP server
-
-To delete the MCP server and all its Cloudflare resources:
-
-```bash
-<%= packageManager %> run delete
-```
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:8787/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/cloudflare-ts/README.md.template
+++ b/libs/create-modelfetch/templates/cloudflare-ts/README.md.template
@@ -6,7 +6,7 @@ An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 <%= packageManager %> run dev
@@ -14,31 +14,29 @@ Start the MCP server:
 
 ### Deploying the MCP server
 
-Deploy the MCP server to Cloudflare:
+Deploy your MCP server to Cloudflare:
 
 ```bash
 <%= packageManager %> run deploy
 ```
 
-After deployment, the output will show your MCP server URL.
+### Deleting the MCP server
+
+Delete your MCP server and all its Cloudflare resources:
+
+```bash
+<%= packageManager %> run delete
+```
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:8787/mcp` (or the URL shown in the output).
-
-### Deleting the MCP server
-
-To delete the MCP server and all its Cloudflare resources:
-
-```bash
-<%= packageManager %> run delete
-```
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:8787/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/deno-js/README.md.template
+++ b/libs/create-modelfetch/templates/deno-js/README.md.template
@@ -6,7 +6,7 @@ An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 deno task start
@@ -14,13 +14,13 @@ deno task start
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:8000/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:8000/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/deno-ts/README.md.template
+++ b/libs/create-modelfetch/templates/deno-ts/README.md.template
@@ -6,7 +6,7 @@ An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 deno task start
@@ -14,13 +14,13 @@ deno task start
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:8000/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:8000/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/fastly-js/README.md.template
+++ b/libs/create-modelfetch/templates/fastly-js/README.md.template
@@ -6,7 +6,7 @@ An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 <%= packageManager %> start
@@ -14,23 +14,21 @@ Start the MCP server:
 
 ### Deploying the MCP server
 
-Deploy the MCP server to Fastly:
+Deploy your MCP server to Fastly:
 
 ```bash
 <%= packageManager %> run deploy
 ```
 
-After deployment, the output will show your MCP server URL.
-
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:7676/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:7676/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/fastly-ts/README.md.template
+++ b/libs/create-modelfetch/templates/fastly-ts/README.md.template
@@ -6,7 +6,7 @@ An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 <%= packageManager %> start
@@ -14,23 +14,21 @@ Start the MCP server:
 
 ### Deploying the MCP server
 
-Deploy the MCP server to Fastly:
+Deploy your MCP server to Fastly:
 
 ```bash
 <%= packageManager %> run deploy
 ```
 
-After deployment, the output will show your MCP server URL.
-
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:7676/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:7676/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/gcore-js/README.md.template
+++ b/libs/create-modelfetch/templates/gcore-js/README.md.template
@@ -6,23 +6,21 @@ An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ### Deploying the MCP server
 
-Deploy the MCP server to Gcore:
+Deploy your MCP server to Gcore:
 
 ```bash
 <%= packageManager %> run deploy
 ```
 
-After deployment, the output will show your MCP server URL.
-
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at the URL shown in the output (ends with `/mcp`).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `<mcp-server-url>/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/gcore-js/deploy.js.template
+++ b/libs/create-modelfetch/templates/gcore-js/deploy.js.template
@@ -75,4 +75,5 @@ if (!deployResponse.ok) {
   );
 }
 
-console.log((await deployResponse.json()).url + "/mcp");
+const { url } = await deployResponse.json();
+console.log(`MCP Server URL: ${url}`);

--- a/libs/create-modelfetch/templates/gcore-ts/README.md.template
+++ b/libs/create-modelfetch/templates/gcore-ts/README.md.template
@@ -6,23 +6,21 @@ An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ### Deploying the MCP server
 
-Deploy the MCP server to Gcore:
+Deploy your MCP server to Gcore:
 
 ```bash
 <%= packageManager %> run deploy
 ```
 
-After deployment, the output will show your MCP server URL.
-
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at the URL shown in the output (ends with `/mcp`).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `<mcp-server-url>/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/gcore-ts/deploy.js.template
+++ b/libs/create-modelfetch/templates/gcore-ts/deploy.js.template
@@ -75,4 +75,5 @@ if (!deployResponse.ok) {
   );
 }
 
-console.log((await deployResponse.json()).url + "/mcp");
+const { url } = await deployResponse.json();
+console.log(`MCP Server URL: ${url}`);

--- a/libs/create-modelfetch/templates/netlify-js/README.md.template
+++ b/libs/create-modelfetch/templates/netlify-js/README.md.template
@@ -6,7 +6,7 @@ An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 deno task dev
@@ -14,23 +14,21 @@ deno task dev
 
 ### Deploying the MCP server
 
-Deploy the MCP server to Netlify:
+Deploy your MCP server to Netlify:
 
 ```bash
 deno task deploy
 ```
 
-After deployment, the output will show your MCP server URL.
-
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:8888/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:8888/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/netlify-ts/README.md.template
+++ b/libs/create-modelfetch/templates/netlify-ts/README.md.template
@@ -6,7 +6,7 @@ An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 deno task dev
@@ -14,23 +14,21 @@ deno task dev
 
 ### Deploying the MCP server
 
-Deploy the MCP server to Netlify:
+Deploy your MCP server to Netlify:
 
 ```bash
 deno task deploy
 ```
 
-After deployment, the output will show your MCP server URL.
-
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:8888/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:8888/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/next-js/README.md.template
+++ b/libs/create-modelfetch/templates/next-js/README.md.template
@@ -6,7 +6,7 @@ An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 <%= packageManager %> run dev
@@ -14,13 +14,13 @@ Start the MCP server:
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:3000/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:3000/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/next-ts/README.md.template
+++ b/libs/create-modelfetch/templates/next-ts/README.md.template
@@ -6,7 +6,7 @@ An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 <%= packageManager %> run dev
@@ -14,13 +14,13 @@ Start the MCP server:
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:3000/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:3000/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/node-js/README.md.template
+++ b/libs/create-modelfetch/templates/node-js/README.md.template
@@ -6,7 +6,7 @@ An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 <%= packageManager %> start
@@ -14,13 +14,13 @@ Start the MCP server:
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:3000/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:3000/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/node-ts/README.md.template
+++ b/libs/create-modelfetch/templates/node-ts/README.md.template
@@ -6,7 +6,7 @@ An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 <%= packageManager %> start
@@ -14,13 +14,13 @@ Start the MCP server:
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:3000/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:3000/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/supabase-js/README.md.template
+++ b/libs/create-modelfetch/templates/supabase-js/README.md.template
@@ -6,7 +6,7 @@ An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 supabase start
@@ -22,23 +22,21 @@ supabase stop
 
 ### Deploying the MCP server
 
-Deploy the MCP server to Supabase:
+Deploy your MCP server to Supabase:
 
 ```bash
 supabase functions deploy mcp-server
 ```
 
-After deployment, the output will show your MCP server URL.
-
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:54321/functions/v1/mcp-server/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:54321/functions/v1/mcp-server/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/supabase-ts/README.md.template
+++ b/libs/create-modelfetch/templates/supabase-ts/README.md.template
@@ -6,7 +6,7 @@ An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 supabase start
@@ -22,23 +22,21 @@ supabase stop
 
 ### Deploying the MCP server
 
-Deploy the MCP server to Supabase:
+Deploy your MCP server to Supabase:
 
 ```bash
 supabase functions deploy mcp-server
 ```
 
-After deployment, the output will show your MCP server URL.
-
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:54321/functions/v1/mcp-server/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:54321/functions/v1/mcp-server/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/vercel-js/README.md.template
+++ b/libs/create-modelfetch/templates/vercel-js/README.md.template
@@ -6,7 +6,7 @@ An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 <%= packageManager %> run dev
@@ -14,13 +14,13 @@ Start the MCP server:
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:3000/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:3000/mcp`).
 
 ## Project Structure
 

--- a/libs/create-modelfetch/templates/vercel-ts/README.md.template
+++ b/libs/create-modelfetch/templates/vercel-ts/README.md.template
@@ -6,7 +6,7 @@ An MCP server built with [ModelFetch](https://www.modelfetch.com)
 
 ### Running the MCP server
 
-Start the MCP server:
+Run your MCP server locally:
 
 ```bash
 <%= packageManager %> run dev
@@ -14,13 +14,13 @@ Start the MCP server:
 
 ### Testing with the MCP Inspector
 
-In a separate terminal, run the MCP Inspector to test your server:
+Run the MCP Inspector locally:
 
 ```bash
 npx -y @modelcontextprotocol/inspector@latest
 ```
 
-Then, connect to your server at `http://localhost:3000/mcp` (or the URL shown in the output).
+Then, connect to your MCP server using Streamable HTTP transport (default URL: `http://localhost:3000/mcp`).
 
 ## Project Structure
 

--- a/libs/modelfetch-bun/src/index.ts
+++ b/libs/modelfetch-bun/src/index.ts
@@ -11,7 +11,7 @@ export function getEndpoint(server: Bun.Server): string {
     server.hostname === "127.0.0.1"
       ? "localhost"
       : server.hostname;
-  return `http://${hostname}:${server.port}/mcp`;
+  return `http://${hostname}:${server.port}`;
 }
 
 export type Options = Except<Bun.ServeOptions, "fetch">;

--- a/libs/modelfetch-deno/src/index.ts
+++ b/libs/modelfetch-deno/src/index.ts
@@ -44,7 +44,7 @@ export function getEndpoint(address: Deno.Addr): string {
       address.hostname === "127.0.0.1"
         ? "localhost"
         : address.hostname;
-    return `http://${hostname}:${address.port}/mcp`;
+    return `http://${hostname}:${address.port}`;
   }
   throw new Error(
     `'${address.transport}' transport is not supported (only TCP and UDP transports are supported)`,

--- a/libs/modelfetch-node/src/index.ts
+++ b/libs/modelfetch-node/src/index.ts
@@ -21,7 +21,7 @@ export function getEndpoint(address: AddressInfo): string {
         ? "localhost"
         : address.address;
   }
-  return `http://${hostname}:${address.port}/mcp`;
+  return `http://${hostname}:${address.port}`;
 }
 
 export type Callback = Args[1];

--- a/libs/nx-10x/src/executors/deploy-gcore-fastedge/index.ts
+++ b/libs/nx-10x/src/executors/deploy-gcore-fastedge/index.ts
@@ -80,6 +80,6 @@ export default async function deployGcoreFastedgeExecutor(
   const createOrUpdateResult = (await createOrUpdateResponse.json()) as {
     url: string;
   };
-  logger.info(`URL: ${createOrUpdateResult.url}/mcp`);
+  logger.info(`MCP Server URL: ${createOrUpdateResult.url}`);
   return { success: true };
 }


### PR DESCRIPTION
## Summary
- Updated getEndpoint functions to return only origin URLs without hardcoded `/mcp` paths
- Improved documentation consistency across all runtime environments
- Standardized README section headings and instructions

## Changes
- **Runtime Libraries**: Modified `getEndpoint` functions in Node.js, Bun, and Deno packages to return only the origin URL, enabling more flexible path configuration
- **Deployment Scripts**: Updated Gcore and AWS Lambda deployment scripts to output cleaner "MCP Server URL" messages without appending paths
- **Documentation**: Standardized all README files and templates with:
  - "Deploy your MCP server to <platform>:" for deployment sections
  - "Run your MCP server locally:" for local development sections  
  - "Run the MCP Inspector locally:" for testing sections
  - Proper verb usage (AWS Lambda uses "Destroying", Cloudflare uses "Deleting")
  - Cleaner connection instructions with appropriate default URLs
  - Removed redundant text and fixed formatting issues

## Test Plan
- [x] All TypeScript files type check successfully
- [x] All files pass linting
- [x] Documentation is consistent across all runtime environments
- [x] Deployment scripts output clean URLs without hardcoded paths

🤖 Generated with [Claude Code](https://claude.ai/code)