### PR TITLE
Configure exclusions for Conductor worktree directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.nx/cache
 /.nx/workspace-data
 .DS_Store
+.conductor
 *.tsbuildinfo
 node_modules
 dist

--- a/.nxignore
+++ b/.nxignore
@@ -2,7 +2,6 @@
 /.nx
 /.husky
 /.vscode
-/.github
 /.gitattributes
 /.nvmrc
 /.prettierignore
@@ -10,6 +9,7 @@
 /.mcp.json
 /tsconfig.json
 /CHANGELOG.md
+.github
 .cursor
 .claude
 CLAUDE.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,6 +32,7 @@
     ".husky/_": true,
     ".github/instructions/nx.instructions.md": true,
     ".cursor/rules/nx-rules.mdc": true,
+    "**/.conductor": true,
     "**/*.tsbuildinfo": true,
     "**/node_modules": true,
     "**/dist": true,

--- a/libs/create-eslint-config/src/index.js
+++ b/libs/create-eslint-config/src/index.js
@@ -14,6 +14,7 @@ export default function createESLintConfig(...configs) {
         "**/*.jsx",
         "**/*.[cm]js",
         "**/.nx",
+        "**/.conductor",
         "**/dist",
         "**/.source",
         "**/next-env.d.ts",


### PR DESCRIPTION
## Summary
- Add `.conductor` to ignore patterns across various tools to prevent conflicts when using Conductor's worktree-based workflow
- Ensures Git, Nx, VS Code, and ESLint all properly exclude Conductor worktree directories
- Prevents performance issues and tool confusion from nested worktrees

## Changes
- `.gitignore`: Add `.conductor` to prevent Git from tracking worktree contents
- `.nxignore`: Clean up `.github` pattern formatting
- `.vscode/settings.json`: Exclude `.conductor` from VS Code file explorer and indexing
- `libs/create-eslint-config/src/index.js`: Add `.conductor` to ESLint ignore patterns

## Test plan
- [x] Verify `.conductor` directories are not tracked by Git
- [x] Confirm Nx commands ignore `.conductor` directories
- [x] Check VS Code doesn't show `.conductor` in file explorer
- [x] Ensure ESLint skips `.conductor` directories during linting

🤖 Generated with [Claude Code](https://claude.ai/code)