### PR TITLE
Add runtime detection for serve command in modelfetch CLI

### DIFF
--- a/libs/modelfetch/src/index.ts
+++ b/libs/modelfetch/src/index.ts
@@ -83,6 +83,18 @@ async function detectDefaultServer(): Promise<string> {
   return "";
 }
 
+function detectRuntimeArgs(): string[] {
+  // @ts-expect-error Bun global may not exist
+  if (typeof Bun !== "undefined") {
+    return ["bun", "run"];
+  }
+  // @ts-expect-error Deno global may not exist
+  if (typeof Deno !== "undefined") {
+    return ["deno", "run", "-A"];
+  }
+  return ["node"];
+}
+
 const killSignals = ["SIGINT", "SIGTERM"] as const;
 
 const program = new Command();
@@ -154,7 +166,7 @@ program
           ),
         ),
         "--",
-        "node",
+        ...detectRuntimeArgs(),
         fileURLToPath(import.meta.url),
         "serve",
       ],


### PR DESCRIPTION
## Summary
- Added automatic runtime detection for the serve command
- The CLI now detects whether it's running under Bun, Deno, or Node.js
- Uses the appropriate runtime command with necessary flags

## Changes
- Added `detectRuntimeArgs()` function that returns the correct runtime command:
  - Bun: `["bun", "run"]`
  - Deno: `["deno", "run", "-A"]`
  - Node.js: `["node"]` (default)
- Updated the dev command to use the detected runtime for the server process
- The MCP Inspector itself always runs with Node.js, only the server command after '--' uses the detected runtime

## Test plan
- [ ] Test with Node.js runtime (default behavior)
- [ ] Test with Bun runtime if available
- [ ] Test with Deno runtime if available
- [ ] Verify MCP Inspector launches correctly with all runtimes

🤖 Generated with [Claude Code](https://claude.ai/code)