### PR TITLE
Fix runtime detection in modelfetch CLI

### DIFF
--- a/.nx/version-plans/fix-runtime-detection.md
+++ b/.nx/version-plans/fix-runtime-detection.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Fix runtime detection in modelfetch CLI by using js-runtime package for accurate Bun/Deno/Node detection

--- a/libs/modelfetch/package.json
+++ b/libs/modelfetch/package.json
@@ -54,6 +54,7 @@
     "c12": "^3.2.0",
     "chokidar": "^4.0.3",
     "commander": "^14.0.0",
+    "js-runtime": "^0.0.8",
     "tailwindcss": "^4.1.11",
     "tsx": "^4.20.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -776,6 +776,9 @@ importers:
       commander:
         specifier: ^14.0.0
         version: 14.0.0
+      js-runtime:
+        specifier: ^0.0.8
+        version: 0.0.8
       tailwindcss:
         specifier: ^4.1.11
         version: 4.1.11
@@ -5674,6 +5677,10 @@ packages:
 
   js-image-generator@1.0.4:
     resolution: {integrity: sha512-ckb7kyVojGAnArouVR+5lBIuwU1fcrn7E/YYSd0FK7oIngAkMmRvHASLro9Zt5SQdWToaI66NybG+OGxPw/HlQ==}
+
+  js-runtime@0.0.8:
+    resolution: {integrity: sha512-/nxfuHRkzajgNgGP/7j2A9y8k54XtTWizq+vEGrWh3eBWlSqFhwgToXHAGZeHX3wRMTC3VFBw1iVeemlX4qxZw==}
+    engines: {node: '>=18', pnpm: '>=8.3.0'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -12786,6 +12793,8 @@ snapshots:
   js-image-generator@1.0.4:
     dependencies:
       jpeg-js: 0.4.4
+
+  js-runtime@0.0.8: {}
 
   js-tokens@4.0.0: {}
 


### PR DESCRIPTION
## Summary
- Replaced custom runtime detection logic with the `js-runtime` npm package
- Fixed issue where Bun runtime wasn't being detected correctly in the serve command  
- Ensures correct runtime (Bun/Deno/Node) is used for both MCP Inspector and server processes

## Test plan
- [ ] Test modelfetch CLI with Node.js projects
- [ ] Test modelfetch CLI with Bun projects (create bun.lockb file)
- [ ] Test modelfetch CLI with Deno projects (create deno.json file)
- [ ] Verify `modelfetch dev` command works correctly with each runtime
- [ ] Verify `modelfetch serve` command works correctly with each runtime

🤖 Generated with [Claude Code](https://claude.ai/code)