### PR TITLE
Fix Deno runtime support in modelfetch CLI

### DIFF
--- a/.nx/version-plans/fix-deno-serve-command.md
+++ b/.nx/version-plans/fix-deno-serve-command.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Fix Deno runtime support in modelfetch serve command by using native Deno watch-hmr instead of tsx


### PR DESCRIPTION
## Summary
- Fixed Deno runtime support in the modelfetch serve command
- Implemented native Deno --watch-hmr instead of using tsx (which isn't compatible with Deno)
- Added proper cleanup of temporary files on process exit

## Implementation Details
For Deno runtime, the serve command now:
1. Generates a temporary TypeScript file that imports the user's server and connects it to StdioServerTransport
2. Spawns `deno run -A --watch-hmr` with the generated file
3. Lets Deno's built-in hot module replacement handle all watching and reloading
4. Cleans up the temporary file on process exit

Node.js and Bun continue to use the existing tsx-based hot reload implementation.

## Test Plan
- [ ] Test modelfetch serve command with Node.js runtime
- [ ] Test modelfetch serve command with Bun runtime  
- [ ] Test modelfetch serve command with Deno runtime
- [ ] Verify hot reload works correctly in all runtimes
- [ ] Verify temporary files are cleaned up properly

🤖 Generated with [Claude Code](https://claude.ai/code)