### PR TITLE
Add file-based logging to modelfetch CLI

### DIFF
--- a/.nx/version-plans/add-file-logging.md
+++ b/.nx/version-plans/add-file-logging.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Add file-based logging to modelfetch CLI for debugging and monitoring sessions


### PR DESCRIPTION
## Summary
- Implemented file-based logging for the modelfetch CLI to enable debugging and monitoring without interfering with console I/O
- Logs are written to `~/.modelfetch/logs/session-{uuid}.log` with unique session IDs
- Added logging for session start, command execution, working directory, and environment variables

## Test plan
- [ ] Run `pnpm exec nx run modelfetch:modelfetch -- dev` and verify log file is created
- [ ] Check that log file contains session information and command execution details
- [ ] Verify that console output is not affected by logging

🤖 Generated with Claude Code (https://claude.ai/code)