### PR TITLE
Improve modelfetch CLI logging and Deno support

### DIFF
--- a/.nx/version-plans/improve-modelfetch-cli-logging.md
+++ b/.nx/version-plans/improve-modelfetch-cli-logging.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Improve modelfetch CLI logging and Deno support with better runtime info and cleaner entry point


### PR DESCRIPTION
## Summary
- Reorganized logging with cleaner command info display and runtime information
- Fixed Deno entry point to use `.modelfetch/main.ts` for proper import map support
- Removed redundant session logging for cleaner output

## Test plan
- [ ] Test `modelfetch serve` command with Node.js runtime
- [ ] Test `modelfetch serve` command with Deno runtime  
- [ ] Test `modelfetch dev` command
- [ ] Verify logging output shows command info and runtime correctly
- [ ] Verify Deno execution respects import maps in the current directory

🤖 Generated with [Claude Code](https://claude.ai/code)