### PR TITLE
Improve modelfetch CLI with cleaner logging and native hot reload

### DIFF
--- a/.nx/version-plans/improve-cli-logging-and-hot-reload.md
+++ b/.nx/version-plans/improve-cli-logging-and-hot-reload.md
@@ -1,5 +1,5 @@
 ---
-__default__: minor
+__default__: patch
 ---
 
-Improve modelfetch CLI with cleaner logging and native hot reload support for Bun runtime
+Remove CLI logs, use native hot reload support for Bun runtime, and surpress buggy stdio messages

--- a/.nx/version-plans/improve-cli-logging-and-hot-reload.md
+++ b/.nx/version-plans/improve-cli-logging-and-hot-reload.md
@@ -1,0 +1,5 @@
+---
+__default__: minor
+---
+
+Improve modelfetch CLI with cleaner logging and native hot reload support for Bun runtime


### PR DESCRIPTION
## Summary
- Removed file-based logging system to reduce clutter and simplify the CLI
- Refactored runtime detection to use shared constants for better maintainability
- Added native hot reload support for Bun runtime using `--hot` flag, similar to Deno's implementation

## Test plan
- [ ] Test `modelfetch serve` command with Node.js runtime
- [ ] Test `modelfetch serve` command with Deno runtime (with hot reload)
- [ ] Test `modelfetch serve` command with Bun runtime (with hot reload)
- [ ] Test `modelfetch dev` command with all runtimes
- [ ] Verify no logging files are created in ~/.modelfetch/logs

🤖 Generated with [Claude Code](https://claude.ai/code)