### PR TITLE
Update Nx target naming conventions for improved clarity

### DIFF
--- a/.nx/version-plans/update-nx-target-naming.md
+++ b/.nx/version-plans/update-nx-target-naming.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Update Nx target naming conventions for improved clarity and organization

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,9 +344,8 @@ When testing the `modelfetch` CLI, use the Nx run command instead of executing t
 
 ```bash
 # ✅ Good - Use Nx run command
-pnpm exec nx run modelfetch:modelfetch -- dev
-pnpm exec nx run modelfetch:modelfetch -- --help
-pnpm exec nx run modelfetch:modelfetch -- --version
+pnpm exec nx run modelfetch:bin:modelfetch -- dev
+pnpm exec nx run modelfetch:bin:modelfetch -- --help
 
 # ❌ Bad - Running the binary directly
 node libs/modelfetch/bin/index.js dev

--- a/libs/nx-10x/src/index.ts
+++ b/libs/nx-10x/src/index.ts
@@ -276,7 +276,7 @@ export const createNodesV2: CreateNodesV2 = [
               ? { [packageJson.name]: packageJson.bin }
               : packageJson.bin;
           for (const [binName, binPath] of Object.entries(binEntries)) {
-            targets[binName] = {
+            targets[`bin:${binName}`] = {
               command: `node ${binPath}`,
               options: { cwd: "{projectRoot}" },
               continuous: true,
@@ -288,14 +288,14 @@ export const createNodesV2: CreateNodesV2 = [
           packageJson.dependencies?.modelfetch ||
           packageJson.devDependencies?.modelfetch
         ) {
-          targets["modelfetch-serve"] = {
-            command: "modelfetch serve",
+          targets["mcp:dev"] = {
+            command: "modelfetch dev",
             options: { cwd: "{projectRoot}" },
             continuous: true,
             dependsOn: ["build", "^build"],
           };
-          targets["modelfetch-dev"] = {
-            command: "modelfetch dev",
+          targets["mcp:serve"] = {
+            command: "modelfetch serve",
             options: { cwd: "{projectRoot}" },
             continuous: true,
             dependsOn: ["build", "^build"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2556,21 +2556,21 @@ packages:
     resolution: {integrity: sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jridgewell/gen-mapping@0.3.12':
-    resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/source-map@0.3.10':
-    resolution: {integrity: sha512-0pPkgz9dY+bijgistcTTJ5mR+ocqRXLuhXHYdzoMmmoJ2C9S46RCm2GMUbatPEUK9Yjy26IrAy8D/M00lLkv+Q==}
+  '@jridgewell/source-map@0.3.11':
+    resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
 
-  '@jridgewell/sourcemap-codec@1.5.4':
-    resolution: {integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==}
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@jridgewell/trace-mapping@0.3.29':
-    resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
+  '@jridgewell/trace-mapping@0.3.30':
+    resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -7686,8 +7686,8 @@ snapshots:
 
   '@ampproject/remapping@2.3.0':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.30
 
   '@aws-cdk/asset-awscli-v1@2.2.242': {}
 
@@ -7736,8 +7736,8 @@ snapshots:
     dependencies:
       '@babel/parser': 7.28.0
       '@babel/types': 7.28.2
-      '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.30
       jsesc: 3.1.0
 
   '@babel/helper-annotate-as-pure@7.27.3':
@@ -9093,29 +9093,29 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.34.38
 
-  '@jridgewell/gen-mapping@0.3.12':
+  '@jridgewell/gen-mapping@0.3.13':
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.4
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.30
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
-  '@jridgewell/source-map@0.3.10':
+  '@jridgewell/source-map@0.3.11':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.30
 
-  '@jridgewell/sourcemap-codec@1.5.4': {}
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@jridgewell/trace-mapping@0.3.29':
+  '@jridgewell/trace-mapping@0.3.30':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.4
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.4
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@mantine/hooks@8.2.4(react@19.1.1)':
     dependencies:
@@ -12969,7 +12969,7 @@ snapshots:
 
   magic-string@0.30.17:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.4
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   make-dir@1.3.0:
     dependencies:
@@ -14815,7 +14815,7 @@ snapshots:
 
   terser@5.43.1:
     dependencies:
-      '@jridgewell/source-map': 0.3.10
+      '@jridgewell/source-map': 0.3.11
       acorn: 8.15.0
       commander: 2.20.3
       source-map-support: 0.5.21


### PR DESCRIPTION
## Summary
- Introduced clearer naming conventions for Nx targets using prefixes (`bin:` for binaries, `mcp:` for ModelFetch commands)
- Reordered commands in modelfetch CLI for better user experience
- Updated documentation to reflect new target naming conventions

## Test plan
- [x] All type checks pass
- [x] All linting checks pass  
- [x] Code formatting applied
- [x] Version plan created for patch release

🤖 Generated with Claude Code (https://claude.ai/code)