### PR TITLE
Add missing modelfetch package version to create-modelfetch CLI

### DIFF
--- a/.nx/version-plans/add-modelfetch-package-version.md
+++ b/.nx/version-plans/add-modelfetch-package-version.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Add missing modelfetch package version to create-modelfetch CLI templates

--- a/libs/create-modelfetch/src/index.ts
+++ b/libs/create-modelfetch/src/index.ts
@@ -26,6 +26,7 @@ const packageVersions = {
   zod: "3.25.76",
   tslib: "2.8.1",
   typescript: "5.9.2",
+  modelfetch: packageJson.version,
   "@modelfetch/node": packageJson.version,
   "@types/node": "22.17.1",
   tsx: "4.20.4",


### PR DESCRIPTION
## Summary
- Added the missing `modelfetch` package version to the `packageVersions` object in the create-modelfetch CLI
- This ensures new projects scaffolded with create-modelfetch can properly reference the main modelfetch package

## Test plan
- [ ] Run `pnpm exec nx run create-modelfetch:build` to verify the build succeeds
- [ ] Test scaffolding a new project with the CLI to ensure the modelfetch package version is correctly included

🤖 Generated with [Claude Code](https://claude.ai/code)