### PR TITLE
Standardize MCP server script naming across all templates

### DIFF
--- a/.nx/version-plans/standardize-mcp-server-scripts.md
+++ b/.nx/version-plans/standardize-mcp-server-scripts.md
@@ -1,5 +1,5 @@
 ---
-__default__: minor
+__default__: patch
 ---
 
 Standardize MCP server script naming to use mcp-server across all create-modelfetch templates

--- a/.nx/version-plans/standardize-mcp-server-scripts.md
+++ b/.nx/version-plans/standardize-mcp-server-scripts.md
@@ -1,0 +1,5 @@
+---
+__default__: minor
+---
+
+Standardize MCP server script naming to use mcp-server across all create-modelfetch templates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,8 +344,8 @@ When testing the `modelfetch` CLI, use the Nx run command instead of executing t
 
 ```bash
 # ✅ Good - Use Nx run command
-pnpm exec nx run modelfetch:bin:modelfetch -- dev
-pnpm exec nx run modelfetch:bin:modelfetch -- --help
+pnpm exec nx run modelfetch:modelfetch -- dev
+pnpm exec nx run modelfetch:modelfetch -- --help
 
 # ❌ Bad - Running the binary directly
 node libs/modelfetch/bin/index.js dev

--- a/apps/example-supabase-js/README.md
+++ b/apps/example-supabase-js/README.md
@@ -36,12 +36,12 @@ Then, connect to your MCP server using Streamable HTTP transport (default URL: `
 ```
 example-supabase-js/
 ├── supabase/
-│   ├── config.toml              # Supabase configuration
-│   └── functions/
-│       └── mcp-server/
-│           ├── deno.json        # Deno configuration
-│           ├── index.js         # Supabase Edge Function entry point
-│           └── server.js        # MCP server implementation
+│   ├── functions/
+│   │   └── mcp-server/
+│   │       ├── deno.json        # Supabase Edge Function Deno configuration
+│   │       ├── index.js         # Supabase Edge Function entry point
+│   │       └── server.js        # MCP server implementation
+│   └── config.toml              # Supabase configuration
 ├── package.json
 └── README.md
 ```

--- a/apps/example-supabase-ts/README.md
+++ b/apps/example-supabase-ts/README.md
@@ -36,12 +36,12 @@ Then, connect to your MCP server using Streamable HTTP transport (default URL: `
 ```
 example-supabase-ts/
 ├── supabase/
-│   ├── config.toml              # Supabase configuration
-│   └── functions/
-│       └── mcp-server/
-│           ├── deno.json        # Deno configuration
-│           ├── index.ts         # Supabase Edge Function entry point
-│           └── server.ts        # MCP server implementation
+│   ├── functions/
+│   │   └── mcp-server/
+│   │       ├── deno.json        # Supabase Edge Function Deno configuration
+│   │       ├── index.ts         # Supabase Edge Function entry point
+│   │       └── server.ts        # MCP server implementation
+│   └── config.toml              # Supabase configuration
 ├── tsconfig.json
 ├── tsconfig.lib.json
 ├── package.json

--- a/libs/create-modelfetch/templates/aws-lambda-js/package.json.template
+++ b/libs/create-modelfetch/templates/aws-lambda-js/package.json.template
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "modelfetch dev",
+    "mcp-server": "modelfetch dev",
     "deploy": "cdk deploy",
     "destroy": "cdk destroy"
   },

--- a/libs/create-modelfetch/templates/aws-lambda-ts/package.json.template
+++ b/libs/create-modelfetch/templates/aws-lambda-ts/package.json.template
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "modelfetch dev",
+    "mcp-server": "modelfetch dev",
     "deploy": "cdk deploy",
     "destroy": "cdk destroy"
   },

--- a/libs/create-modelfetch/templates/azure-functions-js/package.json.template
+++ b/libs/create-modelfetch/templates/azure-functions-js/package.json.template
@@ -6,7 +6,7 @@
   "type": "module",
   "main": "./src/index.js",
   "scripts": {
-    "dev": "modelfetch dev",
+    "mcp-server": "modelfetch dev",
     "start": "func start"
   },
   "dependencies": {

--- a/libs/create-modelfetch/templates/azure-functions-ts/package.json.template
+++ b/libs/create-modelfetch/templates/azure-functions-ts/package.json.template
@@ -6,7 +6,7 @@
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {
-    "dev": "modelfetch dev",
+    "mcp-server": "modelfetch dev",
     "start": "tsc -b && func start"
   },
   "dependencies": {

--- a/libs/create-modelfetch/templates/bun-js/package.json.template
+++ b/libs/create-modelfetch/templates/bun-js/package.json.template
@@ -6,7 +6,7 @@
   "type": "module",
   "main": "./src/index.js",
   "scripts": {
-    "dev": "modelfetch dev",
+    "mcp-server": "modelfetch dev",
     "start": "bun ."
   },
   "dependencies": {

--- a/libs/create-modelfetch/templates/bun-ts/package.json.template
+++ b/libs/create-modelfetch/templates/bun-ts/package.json.template
@@ -6,7 +6,7 @@
   "type": "module",
   "main": "./src/index.ts",
   "scripts": {
-    "dev": "modelfetch dev",
+    "mcp-server": "modelfetch dev",
     "start": "bun ."
   },
   "dependencies": {

--- a/libs/create-modelfetch/templates/cloudflare-js/package.json.template
+++ b/libs/create-modelfetch/templates/cloudflare-js/package.json.template
@@ -5,6 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "mcp-server": "modelfetch dev",
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "delete": "wrangler delete"
@@ -16,6 +17,7 @@
     "zod": "<%= versions['zod'] %>"
   },
   "devDependencies": {
+    "modelfetch": "<%= versions['modelfetch'] %>",
     "wrangler": "<%= versions['wrangler'] %>"
   }
 }

--- a/libs/create-modelfetch/templates/cloudflare-ts/package.json.template
+++ b/libs/create-modelfetch/templates/cloudflare-ts/package.json.template
@@ -5,6 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "mcp-server": "modelfetch dev",
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "delete": "wrangler delete"
@@ -16,6 +17,7 @@
     "zod": "<%= versions['zod'] %>"
   },
   "devDependencies": {
+    "modelfetch": "<%= versions['modelfetch'] %>",
     "typescript": "<%= versions['typescript'] %>",
     "wrangler": "<%= versions['wrangler'] %>"
   }

--- a/libs/create-modelfetch/templates/deno-js/deno.json.template
+++ b/libs/create-modelfetch/templates/deno-js/deno.json.template
@@ -6,6 +6,7 @@
     "zod": "npm:zod@<%= versions['zod'] %>"
   },
   "tasks": {
+    "mcp-server": "deno run -A npm:modelfetch@<%= versions['modelfetch'] %> dev",
     "start": "deno run -A ./src/index.js"
   }
 }

--- a/libs/create-modelfetch/templates/deno-ts/deno.json.template
+++ b/libs/create-modelfetch/templates/deno-ts/deno.json.template
@@ -6,6 +6,7 @@
     "zod": "npm:zod@<%= versions['zod'] %>"
   },
   "tasks": {
+    "mcp-server": "deno run -A npm:modelfetch@<%= versions['modelfetch'] %> dev",
     "start": "deno run -A ./src/index.ts"
   }
 }

--- a/libs/create-modelfetch/templates/fastly-js/package.json.template
+++ b/libs/create-modelfetch/templates/fastly-js/package.json.template
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "modelfetch dev",
+    "mcp-server": "modelfetch dev",
     "start": "fastly compute serve",
     "deploy": "fastly compute publish"
   },

--- a/libs/create-modelfetch/templates/fastly-ts/package.json.template
+++ b/libs/create-modelfetch/templates/fastly-ts/package.json.template
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "modelfetch dev",
+    "mcp-server": "modelfetch dev",
     "start": "fastly compute serve",
     "deploy": "fastly compute publish"
   },

--- a/libs/create-modelfetch/templates/gcore-js/package.json.template
+++ b/libs/create-modelfetch/templates/gcore-js/package.json.template
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "modelfetch dev",
+    "mcp-server": "modelfetch dev",
     "deploy": "fastedge-build ./src/index.js ./dist/index.wasm && node deploy.js"
   },
   "dependencies": {

--- a/libs/create-modelfetch/templates/gcore-ts/package.json.template
+++ b/libs/create-modelfetch/templates/gcore-ts/package.json.template
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "modelfetch dev",
+    "mcp-server": "modelfetch dev",
     "deploy": "tsc -b && fastedge-build ./dist/index.js ./dist/index.wasm && node deploy.js"
   },
   "dependencies": {

--- a/libs/create-modelfetch/templates/netlify-js/deno.json.template
+++ b/libs/create-modelfetch/templates/netlify-js/deno.json.template
@@ -1,6 +1,7 @@
 {
   "importMap": "./import_map.json",
   "tasks": {
+    "mcp-server": "deno run -A npm:modelfetch@<%= versions['modelfetch'] %> dev",
     "dev": "netlify dev",
     "deploy": "netlify deploy --prod"
   }

--- a/libs/create-modelfetch/templates/netlify-ts/deno.json.template
+++ b/libs/create-modelfetch/templates/netlify-ts/deno.json.template
@@ -1,6 +1,7 @@
 {
   "importMap": "./import_map.json",
   "tasks": {
+    "mcp-server": "deno run -A npm:modelfetch@<%= versions['modelfetch'] %> dev",
     "dev": "netlify dev",
     "deploy": "netlify deploy --prod"
   }

--- a/libs/create-modelfetch/templates/next-js/package.json.template
+++ b/libs/create-modelfetch/templates/next-js/package.json.template
@@ -5,6 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "mcp-server": "modelfetch dev",
     "dev": "next dev",
     "build": "next build",
     "start": "next start"
@@ -17,5 +18,8 @@
     "react-dom": "<%= versions['react-dom'] %>",
     "tslib": "<%= versions['tslib'] %>",
     "zod": "<%= versions['zod'] %>"
+  },
+  "devDependencies": {
+    "modelfetch": "<%= versions['modelfetch'] %>"
   }
 }

--- a/libs/create-modelfetch/templates/next-ts/package.json.template
+++ b/libs/create-modelfetch/templates/next-ts/package.json.template
@@ -5,6 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "mcp-server": "modelfetch dev",
     "dev": "next dev",
     "build": "next build",
     "start": "next start"
@@ -22,6 +23,7 @@
     "@types/node": "<%= versions['@types/node'] %>",
     "@types/react": "<%= versions['@types/react'] %>",
     "@types/react-dom": "<%= versions['@types/react-dom'] %>",
+    "modelfetch": "<%= versions['modelfetch'] %>",
     "typescript": "<%= versions['typescript'] %>"
   }
 }

--- a/libs/create-modelfetch/templates/node-js/package.json.template
+++ b/libs/create-modelfetch/templates/node-js/package.json.template
@@ -6,7 +6,7 @@
   "type": "module",
   "main": "./src/index.js",
   "scripts": {
-    "dev": "modelfetch dev",
+    "mcp-server": "modelfetch dev",
     "start": "node ."
   },
   "dependencies": {

--- a/libs/create-modelfetch/templates/node-ts/package.json.template
+++ b/libs/create-modelfetch/templates/node-ts/package.json.template
@@ -6,7 +6,7 @@
   "type": "module",
   "main": "./src/index.ts",
   "scripts": {
-    "dev": "modelfetch dev",
+    "mcp-server": "modelfetch dev",
     "start": "tsx ."
   },
   "dependencies": {

--- a/libs/create-modelfetch/templates/supabase-js/README.md.template
+++ b/libs/create-modelfetch/templates/supabase-js/README.md.template
@@ -43,12 +43,13 @@ Then, connect to your MCP server using Streamable HTTP transport (default URL: `
 ```
 <%= projectName %>/
 ├── supabase/
-│   ├── config.toml              # Supabase configuration
-│   └── functions/
-│       └── mcp-server/
-│           ├── deno.json        # Deno configuration
-│           ├── index.js         # Supabase Edge Function entry point
-│           └── server.js        # MCP server implementation
+│   ├── functions/
+│   │   └── mcp-server/
+│   │       ├── deno.json        # Supabase Edge Function Deno configuration
+│   │       ├── index.js         # Supabase Edge Function entry point
+│   │       └── server.js        # MCP server implementation
+│   └── config.toml              # Supabase configuration
+├── deno.json                    # Deno configuration
 └── README.md
 ```
 

--- a/libs/create-modelfetch/templates/supabase-js/deno.json.template
+++ b/libs/create-modelfetch/templates/supabase-js/deno.json.template
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "mcp-server": "deno run -A npm:modelfetch@<%= versions['modelfetch'] %> dev"
+  }
+}

--- a/libs/create-modelfetch/templates/supabase-ts/README.md.template
+++ b/libs/create-modelfetch/templates/supabase-ts/README.md.template
@@ -43,12 +43,13 @@ Then, connect to your MCP server using Streamable HTTP transport (default URL: `
 ```
 <%= projectName %>/
 ├── supabase/
-│   ├── config.toml              # Supabase configuration
-│   └── functions/
-│       └── mcp-server/
-│           ├── deno.json        # Deno configuration
-│           ├── index.ts         # Supabase Edge Function entry point
-│           └── server.ts        # MCP server implementation
+│   ├── functions/
+│   │   └── mcp-server/
+│   │       ├── deno.json        # Supabase Edge Function Deno configuration
+│   │       ├── index.ts         # Supabase Edge Function entry point
+│   │       └── server.ts        # MCP server implementation
+│   └── config.toml              # Supabase configuration
+├── deno.json                    # Deno configuration
 └── README.md
 ```
 

--- a/libs/create-modelfetch/templates/supabase-ts/deno.json.template
+++ b/libs/create-modelfetch/templates/supabase-ts/deno.json.template
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "mcp-server": "deno run -A npm:modelfetch@<%= versions['modelfetch'] %> dev"
+  }
+}

--- a/libs/create-modelfetch/templates/vercel-js/package.json.template
+++ b/libs/create-modelfetch/templates/vercel-js/package.json.template
@@ -5,6 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "mcp-server": "modelfetch dev",
     "dev": "next dev",
     "build": "next build",
     "start": "next start"
@@ -17,5 +18,8 @@
     "react-dom": "<%= versions['react-dom'] %>",
     "tslib": "<%= versions['tslib'] %>",
     "zod": "<%= versions['zod'] %>"
+  },
+  "devDependencies": {
+    "modelfetch": "<%= versions['modelfetch'] %>"
   }
 }

--- a/libs/create-modelfetch/templates/vercel-ts/package.json.template
+++ b/libs/create-modelfetch/templates/vercel-ts/package.json.template
@@ -5,6 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "mcp-server": "modelfetch dev",
     "dev": "next dev",
     "build": "next build",
     "start": "next start"
@@ -22,6 +23,7 @@
     "@types/node": "<%= versions['@types/node'] %>",
     "@types/react": "<%= versions['@types/react'] %>",
     "@types/react-dom": "<%= versions['@types/react-dom'] %>",
+    "modelfetch": "<%= versions['modelfetch'] %>",
     "typescript": "<%= versions['typescript'] %>"
   }
 }

--- a/libs/nx-10x/src/index.ts
+++ b/libs/nx-10x/src/index.ts
@@ -276,7 +276,7 @@ export const createNodesV2: CreateNodesV2 = [
               ? { [packageJson.name]: packageJson.bin }
               : packageJson.bin;
           for (const [binName, binPath] of Object.entries(binEntries)) {
-            targets[`bin:${binName}`] = {
+            targets[binName] = {
               command: `node ${binPath}`,
               options: { cwd: "{projectRoot}" },
               continuous: true,
@@ -288,7 +288,7 @@ export const createNodesV2: CreateNodesV2 = [
           packageJson.dependencies?.modelfetch ||
           packageJson.devDependencies?.modelfetch
         ) {
-          targets.inspect = {
+          targets["mcp-server"] = {
             command: "modelfetch dev",
             options: { cwd: "{projectRoot}" },
             continuous: true,


### PR DESCRIPTION
## Summary
- Renamed all `dev` scripts to `mcp-server` in create-modelfetch templates
- Added `modelfetch` devDependency to templates that were missing it
- Added root `deno.json` configuration for Supabase templates with mcp-server task
- Updated Project Structure documentation in README files

## Test plan
- [ ] Run `pnpm exec nx run-many -t typecheck` to verify TypeScript compilation
- [ ] Run `pnpm exec nx run-many -t lint` to verify code quality
- [ ] Test creating new projects with updated templates
- [ ] Verify mcp-server script works correctly in each template

🤖 Generated with [Claude Code](https://claude.ai/code)